### PR TITLE
feat: add explain-spsq skill

### DIFF
--- a/.agents/skills/explain-spsq/SKILL.md
+++ b/.agents/skills/explain-spsq/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: explain-spsq
+description: Explain how SynapSeq `.spsq` sequences work and teach the SPSQ language without creating or editing files. Use when an agent needs to walk through a supplied sequence, describe its options, presets, tracks, inheritance, timeline, transitions, steps, fades, resources, or likely listening experience; explain SPSQ syntax or semantics; or identify and explain problems in an invalid sequence. Do not use for creating, editing, repairing, or rewriting `.spsq` or `.spsc` files; recommend `$create-spsq` for those tasks.
+---
+
+# Explain SPSQ Sequences
+
+Explain SPSQ as a readable audio score. Be detailed enough to teach, but adapt the depth and terminology to the user's question. Reply in the user's language even though SPSQ keywords and this skill are in English.
+
+Never create, edit, repair, or rewrite an `.spsq` or `.spsc` file. If the user asks for a change, recommend `$create-spsq`. For a mixed request, explain the existing material and redirect only the creation or editing part.
+
+## Load the language reference
+
+Read [references/spsq-language.md](references/spsq-language.md) before explaining syntax or a sequence. It contains the language model, track meanings, inheritance, timeline behavior, and perceptual vocabulary.
+
+When working inside the SynapSeq repository, consult `docs/SYNTAX.md`, `docs/HOW_IT_WORKS.md`, and the parser or sequence builder only if the bundled reference appears stale or does not cover the requested feature. Treat the current parser and sequence builder as authoritative.
+
+## Choose the explanation mode
+
+Use **file walkthrough** when the user supplies or points to an `.spsq` file or pastes SPSQ content. Use **language lesson** when the user asks how SPSQ syntax or one of its constructs works.
+
+If the user refers to a file that is not available, ask for the file, its path, or its contents. Do not substitute a newly invented sequence.
+
+## Walk through a sequence
+
+1. Read the entire `.spsq`, preserving line numbers for references in the explanation.
+2. Follow each accessible `@extends` dependency and read the complete `.spsc`. Resolve inherited presets conceptually so the user can understand the effective tracks. Do not fetch inaccessible remote dependencies; state what could not be resolved.
+3. Validate without rendering audio. From the SynapSeq repository, prefer:
+
+```bash
+bin/synapseq -test path/to/sequence.spsq
+```
+
+If that binary is unavailable, try an installed `synapseq`, then the repository source:
+
+```bash
+synapseq -test path/to/sequence.spsq
+go run ./cmd/synapseq -test path/to/sequence.spsq
+```
+
+Run only one applicable command. Validation is evidence for the explanation, not permission to modify the file. Never render or play audio.
+
+4. Explain the sequence in this order:
+   - a plain-language overview of the sound and total duration;
+   - top-level options, comments, declared resources, and extends;
+   - each playable preset and template, including inherited overrides and effective track order;
+   - what each track contributes: source, rhythm or beat, waveform, amplitude, smoothness, and effects;
+   - a chronological phase table with interval duration, active preset, transition, steps, and the change toward the next entry;
+   - fades, incompatible-channel crossfades, repeated presets, and the role of `silence`;
+   - the likely perceptual progression and practical listening notes.
+5. Tie non-obvious claims to source line numbers or short source fragments. Distinguish explicit facts from likely intent inferred from names, comments, or parameter choices.
+6. End with validation status, unresolved dependencies, or uncertainties only when any exist.
+
+Do not dump every numeric field into prose. Group stable facts in compact tables and spend detail on relationships, changes over time, and surprising semantics. In particular, make clear that a transition written on one timeline entry controls the interval leading to the next entry.
+
+Do not inspect, decode, play, or characterize the actual contents of ambiance or music files. Explain only how the sequence references and processes those sources.
+
+## Explain invalid input
+
+If validation fails:
+
+- explain every portion that remains unambiguous;
+- identify the error with its line, token, rule, and practical consequence;
+- distinguish parser errors from later structural or semantic validation;
+- avoid silently interpreting invalid text as if it were accepted;
+- do not propose a rewritten full file or apply a fix;
+- recommend `$create-spsq` if the user wants the file corrected.
+
+If validation cannot run, say so briefly and perform a structural reading using the bundled reference. Do not imply that the file passed.
+
+## Teach the language
+
+Start with the four-part mental model: options, presets, indented tracks or overrides, and timeline. Then focus on the constructs the user asked about.
+
+For a general syntax lesson, cover:
+
+1. line orientation, whitespace tokenization, comments, and two-space indentation;
+2. options and resource declarations;
+3. normal presets, templates, inheritance, and overrides;
+4. tone, noise, ambiance, and music tracks;
+5. timeline timestamps, transitions, steps, `silence`, fades, and crossfades;
+6. the difference between accepted syntax and perceptual design choices.
+
+Use short illustrative fragments when they make a rule easier to understand. Do not turn the lesson into a customized, complete sequence. If the user asks to convert the lesson into a file, recommend `$create-spsq`.
+
+## Keep claims grounded
+
+- Describe binaural, monaural, isochronic, noise, modulation, spatial movement, and transitions as audio behavior.
+- Mention that binaural material is most meaningful with stereo headphones.
+- Treat focus, relaxation, meditation, sleep, and similar labels as creative intent or likely listening character.
+- Do not promise medical, therapeutic, cognitive, sleep, or brainwave outcomes.
+- Clearly label interpretations of preset names, comments, and frequencies as inference rather than guaranteed purpose.
+
+## Deliver the explanation
+
+Prefer a layered answer that a beginner can enter easily and an experienced user can inspect:
+
+- lead with what the sequence does overall;
+- use one compact timeline table when there are multiple phases;
+- explain specialized terms at first use;
+- cite relevant lines rather than reproducing the entire file;
+- mention `$create-spsq` only when the user requests creation, editing, repair, or a corrected file.

--- a/.agents/skills/explain-spsq/agents/openai.yaml
+++ b/.agents/skills/explain-spsq/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Explain SPSQ"
+  short_description: "Understand SynapSeq sequences and syntax"
+  default_prompt: "Use $explain-spsq to explain how this SynapSeq sequence works."

--- a/.agents/skills/explain-spsq/references/spsq-language.md
+++ b/.agents/skills/explain-spsq/references/spsq-language.md
@@ -1,0 +1,222 @@
+# SPSQ Explanation Reference
+
+## Contents
+
+- [Mental model](#mental-model)
+- [Lines, tokens, and comments](#lines-tokens-and-comments)
+- [Options and resources](#options-and-resources)
+- [Presets, templates, and inheritance](#presets-templates-and-inheritance)
+- [Tracks and perceptual meaning](#tracks-and-perceptual-meaning)
+- [Timeline and transitions](#timeline-and-transitions)
+- [Validation boundaries](#validation-boundaries)
+- [Explanation vocabulary](#explanation-vocabulary)
+
+## Mental model
+
+An `.spsq` file is a text score for an evolving audio session:
+
+1. **Options** configure rendering and declare external resources.
+2. **Presets** describe sound states.
+3. **Tracks and overrides** define or adjust the channels inside those states.
+4. **Timeline entries** place the states in time and describe how one changes toward the next.
+
+Normal content appears in that order. Comments and blank lines may appear anywhere. An `.spsc` file is a reusable preset collection: it accepts options and presets but cannot contain a timeline or another `@extends`.
+
+## Lines, tokens, and comments
+
+SPSQ is line-oriented and tokenized by whitespace. It has no quoted-string syntax, so names and local paths cannot contain spaces.
+
+- Options, presets, and timeline entries are top-level.
+- Tracks and overrides require exactly two ASCII spaces.
+- `# text` is an ordinary structural comment.
+- `## text` is also retained as sequence metadata.
+
+Names begin with an ASCII letter, contain only letters, digits, `_`, or `-`, and have at most 20 characters. `silence` is reserved.
+
+The parser first recognizes individual line shapes. The sequence builder then enforces relationships such as ordering, existence of presets, resource resolution, inheritance, and timeline validity. A line can therefore be syntactically recognizable but structurally invalid.
+
+## Options and resources
+
+Supported top-level forms include:
+
+```spsq
+@samplerate 44100
+@volume 80
+@ambiance rain audio/rain
+@music bed audio/meditation
+@extends presets/base
+```
+
+- Sample rate defaults to `44100` and must be a positive integer.
+- Volume defaults to `100` and accepts `0` through `100`.
+- One-argument `@ambiance` and `@music` forms use the resource name as the path.
+- Local resource paths are relative, use `/`, omit extensions, and cannot contain `..`.
+- Local ambiance tries `.wav` before `.mp3` and loops.
+- Local music tries `.mp3` before `.wav` and does not loop automatically.
+- Local `@extends` resolves to an `.spsc` file.
+- Remote resources must resolve as WAV or MP3 by extension or MIME type.
+
+Options lock when preset, track, override, or timeline content begins. Resource declarations must precede tracks that reference them.
+
+When explaining a sequence, distinguish the declaration from the media itself. An SPSQ file reveals the resource name, location, amplitude, and effects, but not what an uninspected recording contains.
+
+## Presets, templates, and inheritance
+
+A normal preset is a named playable state:
+
+```spsq
+focus
+  tone 220 binaural 10 amplitude 15
+```
+
+A template holds a reusable track layout but cannot be used directly in the timeline:
+
+```spsq
+focus-base as template
+  tone 220 binaural 8 amplitude 12
+  noise pink smooth 25 amplitude 8
+```
+
+A derived preset copies an earlier template and adjusts inherited tracks:
+
+```spsq
+focus-high from focus-base
+  track 1 binaural 12
+  track 2 amplitude +2
+```
+
+Inherited presets cannot add new tracks. An unsigned numeric override replaces the template value; a value beginning with `+` or `-` changes it relatively. Waveform overrides use an absolute keyword.
+
+Explain both the written override and the effective result. Track order matters because corresponding channels interpolate when consecutive presets have compatible sources and effects. Incompatible channels crossfade at their boundary.
+
+Normal presets must contain tracks, directly or through inheritance. Preset names are unique. Up to 31 user presets coexist with built-in `silence`, and a direct preset has at most 16 track slots. Current override indexes accept `1` through `15`.
+
+## Tracks and perceptual meaning
+
+### Tone
+
+```spsq
+  tone 220 amplitude 15
+  tone 220 binaural 10 amplitude 15
+  tone 220 monaural 10 amplitude 15
+  tone 220 isochronic 10 amplitude 15
+  waveform triangle tone 220 binaural 10 amplitude 15
+```
+
+- A pure tone is a generated carrier at the stated frequency.
+- `binaural` sends nearby frequencies to opposite stereo channels; the stated beat is their difference and stereo headphones are the meaningful listening setup.
+- `monaural` mixes nearby frequencies into both channels, producing a physical amplitude beat.
+- `isochronic` gates a tone on and off at the stated rate, creating a pronounced pulse.
+- Waveforms are `sine` (default), `square`, `triangle`, and `sawtooth`. Compared with sine, the others add progressively different harmonic color; avoid claiming an exact subjective effect.
+
+Carrier and beat values must be non-negative. Binaural and monaural values must remain below twice the carrier so their lower component stays positive.
+
+### Noise
+
+```spsq
+  noise white amplitude 10
+  noise pink smooth 20 amplitude 15
+  noise brown effect pan 0.1 intensity 30 amplitude 12
+```
+
+- White noise is brightest and evenly distributed by frequency.
+- Pink noise is more balanced perceptually, with less high-frequency emphasis.
+- Brown noise emphasizes lower frequencies.
+- `smooth` reduces moment-to-moment roughness without changing the noise color; it ranges from `0` through `100`.
+
+### Ambiance and music
+
+```spsq
+  ambiance rain amplitude 20
+  music bed effect modulation 0.1 intensity 25 amplitude 15
+```
+
+These tracks play declared external resources. Ambiance loops; music is finite. Explain their configured role without inferring the recording's contents beyond supplied names or comments.
+
+### Effects and levels
+
+- `pan` moves stereo position.
+- `modulation` varies amplitude.
+- `doppler` adds pitch motion and is supported only for tones.
+- `intensity` controls effect strength.
+- `amplitude` controls a track's level.
+
+Noise, ambiance, and music support `pan` and `modulation`. Numeric amplitude, intensity, smoothness, and volume values are percentages from `0` through `100`. Multiple tracks combine, so a value is not a guarantee of final perceived loudness.
+
+## Timeline and transitions
+
+Timeline form:
+
+```text
+HH:MM:SS PRESET [TRANSITION [STEPS]]
+```
+
+The first entry is `00:00:00`; later timestamps strictly increase; at least two entries are required. Hours use `00`–`23`, and minutes and seconds use `00`–`59`.
+
+The most important reading rule is directional:
+
+> The transition and steps written on an entry govern the interval from that entry toward the next entry.
+
+For example:
+
+```spsq
+00:00:00 silence smooth
+00:00:20 focus
+```
+
+This means “move smoothly from silence toward `focus` during the first 20 seconds.” It does not mean that `smooth` begins after `00:00:20`.
+
+Transitions:
+
+- `steady` is linear and is the default.
+- `ease-in` starts gently and accelerates.
+- `ease-out` starts more quickly and settles gently.
+- `smooth` eases at both ends.
+
+Steps create an alternating forward/backward trajectory before finally arriving at the next state. There are `2 × steps + 1` legs, each needing at least five seconds, with a hard cap of 12 steps. Explain steps as repeated oscillation between endpoint tendencies, not as additional timeline entries.
+
+### Silence and fades
+
+Built-in `silence` needs no declaration. Adjacent `silence -> active` and `active -> silence` boundaries become fade-compatible by retaining the active track shape while taking amplitude from or to zero.
+
+To hold a preset and fade only near the end, the active preset is repeated where the fade starts:
+
+```spsq
+00:14:00 relax smooth
+00:15:00 silence
+```
+
+The `smooth` on the `00:14:00` entry controls the final minute toward silence.
+
+When corresponding channels have incompatible source types, effects, ambiance names, or music names, SynapSeq uses an automatic per-channel crossfade around the boundary. It uses up to 30 seconds on each available side and does not insert new timeline periods. Active-to-off and off-to-active channels receive equivalent boundary fades.
+
+The final timestamp is the sequence duration. Each entry begins a period that lasts until the following timestamp; the final entry marks the terminal state rather than adding an unspecified extra duration.
+
+## Validation boundaries
+
+Common invalid conditions include:
+
+- options after preset or timeline content;
+- a track without exactly two-space indentation;
+- a missing, duplicate, empty, or unknown preset;
+- a template referenced directly by the timeline;
+- a new track declared inside an inherited preset;
+- timeline content inside `.spsc`;
+- a first timestamp other than `00:00:00`;
+- timestamps that do not strictly increase;
+- fewer than two timeline entries;
+- a resource path with an extension, absolute root, backslash, or `..`;
+- out-of-range values or too many steps for the interval.
+
+When explaining invalid input, preserve the difference between intended meaning and accepted behavior. State what the line appears intended to mean, why SynapSeq rejects it, and what consequence that has. Leave correction or rewriting to `$create-spsq`.
+
+## Explanation vocabulary
+
+Use these distinctions consistently:
+
+- **Explicit:** directly declared by syntax, such as duration, carrier frequency, or transition.
+- **Resolved:** inherited or loaded through an accessible `.spsc`.
+- **Inferred:** likely intent suggested by names, comments, or parameter choices.
+- **Unknown:** properties of inaccessible dependencies or uninspected media.
+
+Describe audible and structural behavior without promising focus, relaxation, sleep, treatment, cognitive improvement, or brain-state changes. Such labels express creative intent, not guaranteed outcomes.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <a href="COPYING.txt"><img src="https://img.shields.io/badge/license-GPL%20v3%20or%20later-blue.svg?logo=open-source-initiative&logoColor=white" alt="License"></a>
   <a href="https://github.com/synapseq-foundation/synapseq/commits"><img src="https://img.shields.io/github/commit-activity/m/synapseq-foundation/synapseq?color=ff69b4&logo=git" alt="Commit Activity"></a>
   <a href="https://skills.sh/synapseq-foundation/synapseq/create-spsq"><img src="https://img.shields.io/badge/skills.sh-create--spsq-000000?logo=vercel&logoColor=white" alt="create-spsq on skills.sh"></a>
+  <a href="https://skills.sh/synapseq-foundation/synapseq/explain-spsq"><img src="https://img.shields.io/badge/skills.sh-explain--spsq-000000?logo=vercel&logoColor=white" alt="explain-spsq on skills.sh"></a>
 </p>
 
 <p align="center"><strong>SynapSeq - Text-Driven Audio Sequencer for Brainwave Entrainment</strong></p>
@@ -73,47 +74,55 @@ synapseq focus.spsq
 
 The result is a repeatable audio session generated from the text definition. See [HOW IT WORKS](docs/HOW_IT_WORKS.md) for a perceptual explanation of the tone methods, transitions, and effects.
 
-## Create Sequences With AI Agents
+## Use SPSQ With AI Agents
 
-SynapSeq publishes the [`create-spsq` skill](https://skills.sh/synapseq-foundation/synapseq/create-spsq) for generating, editing, and validating `.spsq` sequences with AI coding agents. Install SynapSeq first using the [Quick Start](#quick-start) instructions so the agent can validate generated files with `synapseq -test`.
+SynapSeq publishes two complementary skills for AI coding agents:
 
-Install the skill interactively from its `skills.sh` source:
+- [`create-spsq`](https://skills.sh/synapseq-foundation/synapseq/create-spsq) creates, edits, repairs, and validates `.spsq` sequences.
+- [`explain-spsq`](https://skills.sh/synapseq-foundation/synapseq/explain-spsq) explains supplied sequences and teaches SPSQ syntax without changing files.
+
+Install either skill interactively from its `skills.sh` source:
 
 ```bash
 npx skills add https://github.com/synapseq-foundation/synapseq --skill create-spsq
+npx skills add https://github.com/synapseq-foundation/synapseq --skill explain-spsq
 ```
 
-To install it globally for a specific agent without prompts, use one of these commands:
+To install a skill globally for a specific agent without prompts, use the corresponding command:
 
 ```bash
 # Codex
 npx skills add https://github.com/synapseq-foundation/synapseq --skill create-spsq --global --agent codex --yes
+npx skills add https://github.com/synapseq-foundation/synapseq --skill explain-spsq --global --agent codex --yes
 
 # Claude Code
 npx skills add https://github.com/synapseq-foundation/synapseq --skill create-spsq --global --agent claude-code --yes
+npx skills add https://github.com/synapseq-foundation/synapseq --skill explain-spsq --global --agent claude-code --yes
 ```
 
 Omit `--global` to install the skill only in the current project.
 
 ### Codex
 
-Start Codex in the directory where you want to create the sequence and mention the skill explicitly with `$create-spsq`:
+Mention the skill explicitly according to the task:
 
 ```text
 $create-spsq Create a 20-minute relaxation sequence with a smooth binaural fade-in and fade-out.
+$explain-spsq Explain the presets, tracks, and timeline in focus.spsq.
 ```
 
 You can also describe the task normally; Codex may select the skill automatically when the request matches its description.
 
 ### Claude Code
 
-Start Claude Code in the target directory and invoke the installed skill as a slash command:
+Invoke the installed skill as a slash command:
 
 ```text
 /create-spsq Create a 20-minute relaxation sequence with a smooth binaural fade-in and fade-out.
+/explain-spsq Explain the presets, tracks, and timeline in focus.spsq.
 ```
 
-Claude Code can also load the skill automatically when a request matches its description. Explicit invocation is the most predictable option for both agents.
+Claude Code can also load a skill automatically when a request matches its description. Explicit invocation is the most predictable option for both agents. Install SynapSeq using the [Quick Start](#quick-start) instructions when the agent needs to validate a local file with `synapseq -test`.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- add the read-only `explain-spsq` skill for file walkthroughs and SPSQ syntax lessons
- include a self-contained SPSQ explanation reference and agent UI metadata
- document installation and usage alongside `create-spsq`

## Validation

- skill `quick_validate.py`
- `openai.yaml` metadata checks
- `git diff --check`
- `make test`
- three independent forward-tests covering valid inheritance, invalid input, and creation redirection