### PR TITLE
feat: make create-spsq sources read-only

### DIFF
--- a/.agents/skills/create-spsq/SKILL.md
+++ b/.agents/skills/create-spsq/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-spsq
-description: Create, edit, review, and validate SynapSeq `.spsq` brainwave-entrainment sequence files. Use when an agent needs to translate a listening goal into SynapSeq presets and timelines, modify an existing sequence, diagnose SynapSeq DSL errors, work with `.spsc` preset libraries, or check a sequence with the SynapSeq CLI.
+description: Create and validate new SynapSeq `.spsq` brainwave-entrainment sequence files. Use when an agent needs to translate a listening goal into a new sequence or create a new adapted, corrected, or extended sequence from an existing read-only `.spsq` reference and its `.spsc` dependencies. Never edit, overwrite, move, or delete an existing sequence or dependency. Use `$explain-spsq` for explanation, review, diagnosis, or validation of an existing file when no new output is requested.
 ---
 
 # Create SPSQ Sequences
@@ -9,7 +9,7 @@ Create syntactically valid, listenable SynapSeq sequences while keeping claims a
 
 ## Load the language reference
 
-Read [references/spsq-language.md](references/spsq-language.md) before writing or editing a sequence. It contains the accepted line forms, validated ranges, timeline semantics, and examples.
+Read [references/spsq-language.md](references/spsq-language.md) before writing a new sequence. It contains the accepted line forms, validated ranges, timeline semantics, and examples.
 
 When working inside the SynapSeq repository, consult `docs/SYNTAX.md` and the parser only if the bundled reference appears stale or the requested feature is not covered. Treat the current parser and sequence builder as authoritative.
 
@@ -21,7 +21,8 @@ Extract these requirements from the request:
 - preferred method: pure tone, binaural, monaural, isochronic, noise, ambiance, music, or a combination;
 - headphone availability when considering binaural beats;
 - available local paths or URLs for ambiance and music;
-- desired output path and whether an existing file must be preserved or edited.
+- desired output path;
+- any existing `.spsq` supplied as a read-only design or content reference.
 
 For a vague request such as “make a focus sequence,” ask only for the missing essentials: duration and whether the user prefers a method or delegates that choice. Ask about headphones only when binaural is a likely choice. Do not block on optional details once those essentials are known.
 
@@ -40,20 +41,35 @@ Treat focus, sleep, relaxation, meditation, and similar terms as creative listen
 
 Do not invent ambiance or music assets. Use only paths, URLs, or named resources supplied by the user or already present in the sequence and its `.spsc` dependencies. If a requested external layer has no source, ask for it or omit that layer and say so.
 
-## Create or edit the file
+## Protect existing files
 
-For a new sequence, use the requested path. If no path is given and filesystem tools are available, choose a short descriptive lowercase hyphenated filename ending in `.spsq` in the current working directory. Otherwise return one fenced `spsq` block.
+Treat every existing file as read-only, including source `.spsq` files, `.spsc` dependencies, ambiance, music, and any path already occupying the requested destination. Never overwrite, edit, format, rename, move, delete, change permissions on, or otherwise mutate them.
 
-For an edit:
+If the user asks to edit, change, adapt, extend, or repair an existing `.spsq`, interpret the request as creating a new derived `.spsq`. Read the entire source and every accessible local `.spsc` it extends, but apply the requested changes only to the new output. Preserve unrelated options, comments, resource declarations, preset names, track order, and formatting when copying material into the derivative.
 
-1. Read the entire target file and any local `.spsc` files it extends.
-2. Preserve unrelated options, comments, resource declarations, preset names, and formatting.
-3. Make the smallest coherent change that satisfies the request.
-4. Recheck channel ordering and every timeline reference after changing presets.
+If the user asks only to explain, review, diagnose, or validate an existing file and does not want a new file, recommend `$explain-spsq`.
+
+## Choose a new output path
+
+For a sequence created from scratch, use the requested path only when it does not exist. If no path is given and filesystem tools are available, choose a short descriptive lowercase hyphenated filename ending in `.spsq` in the current working directory.
+
+For a sequence derived from an existing file:
+
+1. Use an explicitly requested output only when it differs from the source and does not already exist.
+2. If the requested output is the source or any other existing path, do not write; ask for a new path.
+3. If no output is requested, create it beside the source so relative `@extends`, ambiance, and music paths retain their meaning.
+4. Derive a short lowercase hyphenated name from the requested change. If that name exists, add `-2`, `-3`, and so on before `.spsq` until the path is unused.
+5. If the user requests another directory, verify that every relative dependency remains valid from the new location. If SPSQ path rules prevent that, ask for a compatible destination; do not copy or modify dependencies or media.
+
+When filesystem tools are unavailable, return one fenced `spsq` block as a new sequence and state that no file was written.
+
+## Create the file
+
+Write only to the unused output selected above. For a derivative, make the smallest coherent change that satisfies the request and recheck channel ordering and every timeline reference after changing presets. The new output may be revised during its own creation and validation, but its read-only sources and dependencies may not.
 
 Use exactly two ASCII spaces for tracks and overrides. Never use quoted strings: the language tokenizes on whitespace and has no quoting syntax.
 
-## Validate and repair
+## Validate the new output
 
 Validate every file-backed result without rendering audio. From the SynapSeq repository, prefer:
 
@@ -68,7 +84,7 @@ synapseq -test path/to/sequence.spsq
 go run ./cmd/synapseq -test path/to/sequence.spsq
 ```
 
-Run only one applicable command. On failure, use the diagnostic's file, line, span, found token, expected token, and hint to correct the file, then validate again. Do not render or play audio as a substitute for `-test`.
+Run only one applicable command. On failure, use the diagnostic's file, line, span, found token, expected token, and hint to correct only the new output, then validate again. If the failure belongs to a read-only source or dependency, leave it untouched; adjust the new output without mutating inputs when possible, otherwise report the blocker. Do not render or play audio as a substitute for `-test`.
 
 If validation cannot run because the CLI or referenced media is unavailable, perform the structural checklist below and clearly report that validation was not executed:
 
@@ -85,4 +101,4 @@ If validation cannot run because the CLI or referenced media is unavailable, per
 
 ## Deliver the result
 
-State the created or edited path, whether CLI validation passed, and a concise description of the sound sources and phase progression. Mention headphones for binaural content. Do not restate the whole file when it was already written unless the user asks.
+State the newly created path, whether CLI validation passed, and a concise description of the sound sources and phase progression. When a source was provided, explicitly confirm that it and its dependencies were used read-only and left unchanged. Mention headphones for binaural content. Do not restate the whole file when it was already written unless the user asks.

--- a/.agents/skills/create-spsq/agents/openai.yaml
+++ b/.agents/skills/create-spsq/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Create SPSQ"
-  short_description: "Create, edit, and validate SynapSeq sequences"
+  short_description: "Create and validate new SynapSeq sequences"
   default_prompt: "Use $create-spsq to create and validate a SynapSeq sequence for my listening goal."

--- a/.agents/skills/create-spsq/references/spsq-language.md
+++ b/.agents/skills/create-spsq/references/spsq-language.md
@@ -140,7 +140,7 @@ Noise colors are `white`, `pink`, and `brown`. Noise effects are `pan` and `modu
   music bed effect modulation 0.1 intensity 25 amplitude 15
 ```
 
-Ambiance and music support `pan` and `modulation`, not `doppler`. Their source name must match an `@ambiance` or `@music` declaration. Although the current parser permits a waveform prefix for these sources, avoid it unless preserving an existing sequence because waveform is primarily meaningful for generated tones.
+Ambiance and music support `pan` and `modulation`, not `doppler`. Their source name must match an `@ambiance` or `@music` declaration. Although the current parser permits a waveform prefix for these sources, avoid it unless retaining that behavior from a read-only reference in a new derived sequence because waveform is primarily meaningful for generated tones.
 
 ## Values and limits
 

--- a/.agents/skills/explain-spsq/SKILL.md
+++ b/.agents/skills/explain-spsq/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: explain-spsq
-description: Explain how SynapSeq `.spsq` sequences work and teach the SPSQ language without creating or editing files. Use when an agent needs to walk through a supplied sequence, describe its options, presets, tracks, inheritance, timeline, transitions, steps, fades, resources, or likely listening experience; explain SPSQ syntax or semantics; or identify and explain problems in an invalid sequence. Do not use for creating, editing, repairing, or rewriting `.spsq` or `.spsc` files; recommend `$create-spsq` for those tasks.
+description: Explain how SynapSeq `.spsq` sequences work and teach the SPSQ language without creating or editing files. Use when an agent needs to walk through a supplied sequence, describe its options, presets, tracks, inheritance, timeline, transitions, steps, fades, resources, or likely listening experience; explain SPSQ syntax or semantics; or identify and explain problems in an invalid sequence. Do not use to create files; when the user wants changes or corrections, recommend `$create-spsq` to create a new sequence from the existing read-only reference.
 ---
 
 # Explain SPSQ Sequences
 
 Explain SPSQ as a readable audio score. Be detailed enough to teach, but adapt the depth and terminology to the user's question. Reply in the user's language even though SPSQ keywords and this skill are in English.
 
-Never create, edit, repair, or rewrite an `.spsq` or `.spsc` file. If the user asks for a change, recommend `$create-spsq`. For a mixed request, explain the existing material and redirect only the creation or editing part.
+Never create, edit, repair, or rewrite an `.spsq` or `.spsc` file. If the user asks for a change or correction, recommend `$create-spsq` to create a new file while leaving the existing material untouched. For a mixed request, explain the existing material and redirect only the new-file part.
 
 ## Load the language reference
 
@@ -64,7 +64,7 @@ If validation fails:
 - distinguish parser errors from later structural or semantic validation;
 - avoid silently interpreting invalid text as if it were accepted;
 - do not propose a rewritten full file or apply a fix;
-- recommend `$create-spsq` if the user wants the file corrected.
+- recommend `$create-spsq` if the user wants a new corrected file based on the read-only original.
 
 If validation cannot run, say so briefly and perform a structural reading using the bundled reference. Do not imply that the file passed.
 
@@ -81,7 +81,7 @@ For a general syntax lesson, cover:
 5. timeline timestamps, transitions, steps, `silence`, fades, and crossfades;
 6. the difference between accepted syntax and perceptual design choices.
 
-Use short illustrative fragments when they make a rule easier to understand. Do not turn the lesson into a customized, complete sequence. If the user asks to convert the lesson into a file, recommend `$create-spsq`.
+Use short illustrative fragments when they make a rule easier to understand. Do not turn the lesson into a customized, complete sequence. If the user asks to convert the lesson into a new file, recommend `$create-spsq`.
 
 ## Keep claims grounded
 
@@ -99,4 +99,4 @@ Prefer a layered answer that a beginner can enter easily and an experienced user
 - use one compact timeline table when there are multiple phases;
 - explain specialized terms at first use;
 - cite relevant lines rather than reproducing the entire file;
-- mention `$create-spsq` only when the user requests creation, editing, repair, or a corrected file.
+- mention `$create-spsq` only when the user requests a new sequence, including a new adapted or corrected version of existing read-only material.

--- a/.agents/skills/explain-spsq/references/spsq-language.md
+++ b/.agents/skills/explain-spsq/references/spsq-language.md
@@ -208,7 +208,7 @@ Common invalid conditions include:
 - a resource path with an extension, absolute root, backslash, or `..`;
 - out-of-range values or too many steps for the interval.
 
-When explaining invalid input, preserve the difference between intended meaning and accepted behavior. State what the line appears intended to mean, why SynapSeq rejects it, and what consequence that has. Leave correction or rewriting to `$create-spsq`.
+When explaining invalid input, preserve the difference between intended meaning and accepted behavior. State what the line appears intended to mean, why SynapSeq rejects it, and what consequence that has. Leave creation of a corrected copy to `$create-spsq`; the original remains read-only.
 
 ## Explanation vocabulary
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
   <a href="https://github.com/synapseq-foundation/synapseq/releases/latest"><img src="https://img.shields.io/github/v/release/synapseq-foundation/synapseq?color=blue&logo=github" alt="Release"></a>
   <a href="COPYING.txt"><img src="https://img.shields.io/badge/license-GPL%20v3%20or%20later-blue.svg?logo=open-source-initiative&logoColor=white" alt="License"></a>
   <a href="https://github.com/synapseq-foundation/synapseq/commits"><img src="https://img.shields.io/github/commit-activity/m/synapseq-foundation/synapseq?color=ff69b4&logo=git" alt="Commit Activity"></a>
+</p>
+<p align="center">
   <a href="https://skills.sh/synapseq-foundation/synapseq/create-spsq"><img src="https://img.shields.io/badge/skills.sh-create--spsq-000000?logo=vercel&logoColor=white" alt="create-spsq on skills.sh"></a>
   <a href="https://skills.sh/synapseq-foundation/synapseq/explain-spsq"><img src="https://img.shields.io/badge/skills.sh-explain--spsq-000000?logo=vercel&logoColor=white" alt="explain-spsq on skills.sh"></a>
 </p>
@@ -78,7 +80,7 @@ The result is a repeatable audio session generated from the text definition. See
 
 SynapSeq publishes two complementary skills for AI coding agents:
 
-- [`create-spsq`](https://skills.sh/synapseq-foundation/synapseq/create-spsq) creates, edits, repairs, and validates `.spsq` sequences.
+- [`create-spsq`](https://skills.sh/synapseq-foundation/synapseq/create-spsq) creates and validates new `.spsq` sequences, either from scratch or from existing read-only references.
 - [`explain-spsq`](https://skills.sh/synapseq-foundation/synapseq/explain-spsq) explains supplied sequences and teaches SPSQ syntax without changing files.
 
 Install either skill interactively from its `skills.sh` source:


### PR DESCRIPTION
## Summary

- make `create-spsq` create new outputs without mutating existing SPSQ sources or dependencies
- generate collision-safe derivative names and reject overwrite requests
- align `explain-spsq`, skill metadata, and README with the new contract
- place the skills.sh badges on their own centered README row

## Validation

- both skills passed `quick_validate.py`
- `openai.yaml` metadata checks
- `git diff --check`
- `make test`
- forward-tests for new creation, derived copies, collisions, invalid sources, overwrite refusal, review routing, and relative dependencies
- source and dependency hashes remained unchanged