### PR TITLE
feat: add review-spsq audit skill

### DIFF
--- a/.agents/skills/create-spsq/SKILL.md
+++ b/.agents/skills/create-spsq/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-spsq
-description: Create and validate new SynapSeq `.spsq` brainwave-entrainment sequence files. Use when an agent needs to translate a listening goal into a new sequence or create a new adapted, corrected, or extended sequence from an existing read-only `.spsq` reference and its `.spsc` dependencies. Never edit, overwrite, move, or delete an existing sequence or dependency. Use `$explain-spsq` for explanation, review, diagnosis, or validation of an existing file when no new output is requested.
+description: Create and validate new SynapSeq `.spsq` brainwave-entrainment sequence files. Use when an agent needs to translate a listening goal into a new sequence or create a new adapted, corrected, or extended sequence from an existing read-only `.spsq` reference and its `.spsc` dependencies. Never edit, overwrite, move, or delete an existing sequence or dependency. Use `$review-spsq` for technical audit or validation of existing files and `$explain-spsq` for syntax lessons or didactic walkthroughs.
 ---
 
 # Create SPSQ Sequences
@@ -47,7 +47,7 @@ Treat every existing file as read-only, including source `.spsq` files, `.spsc` 
 
 If the user asks to edit, change, adapt, extend, or repair an existing `.spsq`, interpret the request as creating a new derived `.spsq`. Read the entire source and every accessible local `.spsc` it extends, but apply the requested changes only to the new output. Preserve unrelated options, comments, resource declarations, preset names, track order, and formatting when copying material into the derivative.
 
-If the user asks only to explain, review, diagnose, or validate an existing file and does not want a new file, recommend `$explain-spsq`.
+If the user asks only to audit, review, diagnose, or validate an existing file, recommend `$review-spsq`. If the user asks for a syntax lesson or didactic walkthrough, recommend `$explain-spsq`.
 
 ## Choose a new output path
 

--- a/.agents/skills/explain-spsq/SKILL.md
+++ b/.agents/skills/explain-spsq/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: explain-spsq
-description: Explain how SynapSeq `.spsq` sequences work and teach the SPSQ language without creating or editing files. Use when an agent needs to walk through a supplied sequence, describe its options, presets, tracks, inheritance, timeline, transitions, steps, fades, resources, or likely listening experience; explain SPSQ syntax or semantics; or identify and explain problems in an invalid sequence. Do not use to create files; when the user wants changes or corrections, recommend `$create-spsq` to create a new sequence from the existing read-only reference.
+description: Explain how SynapSeq `.spsq` sequences work and teach the SPSQ language without creating or editing files. Use for didactic walkthroughs of supplied sequences and questions about SPSQ syntax, semantics, tracks, inheritance, timelines, transitions, fades, or likely listening experience. Use `$review-spsq` for systematic technical audits, validation, severity-classified findings, or batch review. When the user wants a new changed or corrected file, recommend `$create-spsq`.
 ---
 
 # Explain SPSQ Sequences
@@ -20,6 +20,8 @@ When working inside the SynapSeq repository, consult `docs/SYNTAX.md`, `docs/HOW
 Use **file walkthrough** when the user supplies or points to an `.spsq` file or pastes SPSQ content. Use **language lesson** when the user asks how SPSQ syntax or one of its constructs works.
 
 If the user refers to a file that is not available, ask for the file, its path, or its contents. Do not substitute a newly invented sequence.
+
+If the user asks for a systematic audit, critical assessment, severity-classified report, validation-only check, or review of multiple files, recommend `$review-spsq`.
 
 ## Walk through a sequence
 

--- a/.agents/skills/review-spsq/SKILL.md
+++ b/.agents/skills/review-spsq/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: review-spsq
+description: Audit existing SynapSeq `.spsq` files without modifying them. Use for technical reviews, validation, critique, directory or multi-file audits, and analysis of syntax, builder semantics, dependencies, sound structure, timeline composition, responsible claims, or likely unexpected behavior. Classify findings as critical errors, technical warnings, artistic observations, or optional suggestions. Never save corrections; recommend `$create-spsq` when the user wants a new corrected sequence.
+---
+
+# Review SPSQ Sequences
+
+Review SPSQ files as a technical auditor and thoughtful sound-design critic. Stay read-only even when the user asks to fix, improve, optimize, or apply changes. Reply in the user's language.
+
+## Load the review references
+
+Read all three references before reviewing:
+
+- [references/review-checklist.md](references/review-checklist.md) for objective syntax, semantics, dependencies, and timeline checks;
+- [references/sound-design-guidelines.md](references/sound-design-guidelines.md) for sound structure, artistic judgment, safety, and optional rendered-audio analysis;
+- [references/report-format.md](references/report-format.md) for finding categories and individual or batch reports.
+
+When working inside the SynapSeq repository, also consult `README.md`, `docs/SYNTAX.md`, `docs/HOW_IT_WORKS.md`, and the parser or sequence builder when a bundled reference appears stale or incomplete. Treat the current implementation as authoritative.
+
+## Keep every source read-only
+
+Never create, edit, format, rename, move, delete, or change permissions on an `.spsq`, `.spsc`, ambiance, music, or other project file. Suggestions and short corrected fragments belong only in the report.
+
+If the user asks to apply corrections:
+
+1. complete the read-only review;
+2. state that no file was changed;
+3. show only the smallest useful suggested fragments;
+4. recommend `$create-spsq` to create a new corrected file from the reviewed source.
+
+Do not emit a complete rewritten sequence under this skill.
+
+## Resolve the review scope
+
+- For one or more explicit files, review exactly those files.
+- For a directory, review only `.spsq` files directly inside it by default.
+- Recurse into subdirectories only when the user explicitly requests recursion.
+- In batch mode, sort paths for deterministic output and continue after every individual failure.
+- If no matching `.spsq` exists, report that fact without inventing input.
+
+For every target:
+
+1. read the complete file with line numbers;
+2. locate each `@extends`, `@ambiance`, and `@music`;
+3. read accessible local `.spsc` dependencies completely;
+4. verify local resource resolution and note inaccessible remote resources;
+5. do not characterize uninspected audio from a filename alone.
+
+## Run objective validation
+
+Prefer the bundled validator because it records each file independently and does not stop a batch after the first error:
+
+```bash
+bash scripts/validate.sh path/to/one.spsq path/to/two.spsq
+```
+
+The script selects one available validator in this order: repository `bin/synapseq`, installed `synapseq`, then repository source through `go run`. Record the exact command, output, and exit status reported for each file.
+
+If the script is unavailable, use one applicable command per file:
+
+```bash
+bin/synapseq -test path/to/sequence.spsq
+synapseq -test path/to/sequence.spsq
+go run ./cmd/synapseq -test path/to/sequence.spsq
+```
+
+Never render or play audio as a substitute for `-test`. Never say that a sequence is valid unless an available validator completed successfully. If validation cannot run, label the result **static review only** and state the limitation.
+
+Treat validator diagnostics as critical errors, but do not stop there. The validator establishes accepted syntax and builder semantics; it does not decide whether a valid composition is coherent, efficient, comfortable, or artistically effective.
+
+## Perform the manual audit
+
+Review all five dimensions:
+
+1. syntax;
+2. builder semantics and dependencies;
+3. sound structure;
+4. temporal composition;
+5. responsible positioning.
+
+Use the checklist to find objective failures and likely unexpected behavior. Build the effective track layout of inherited presets before comparing consecutive timeline states. Explain when compatible tracks interpolate, incompatible channels crossfade, and active/off channels use boundary fades.
+
+Calculate the total duration and each timeline interval. Remember that the transition and steps written on one entry govern the interval toward the next entry. A repeated identical preset creates a static hold unless it intentionally marks a later fade or another target follows.
+
+Do not use preference as proof. A dense psychedelic sequence may deliberately use several moving layers. Describe the consequence, classify the risk, and preserve the stated identity rather than prescribing minimalism.
+
+## Classify every finding
+
+Assign exactly one category:
+
+- **Critical error**: invalid syntax or semantics, failed validation, missing required dependency, or another issue that prevents reliable loading or rendering.
+- **Technical warning**: valid but likely unexpected, fragile, excessively dense, inefficient, or difficult to control.
+- **Artistic observation**: a valid characteristic that shapes the experience without being wrong.
+- **Optional suggestion**: a goal-dependent improvement that the author may reasonably reject.
+
+Do not duplicate one finding across categories. Cite file and line numbers when possible. Separate explicit facts from inference.
+
+A commented line resembling an option, such as `# @volume 60`, is not automatically invalid because defaults may apply. Classify it as critical only when the declared intent or a resulting broken dependency makes the missing option essential; otherwise report it as a technical warning and explain the active default.
+
+## Review sound and timeline responsibly
+
+Assess simultaneous tracks, nearby carriers, multiple beat methods, amplitudes, noise density, competing movement effects, waveform character, masking, contrast, abrupt changes, long static phases, entrances, development, landing, and final fade.
+
+Do not:
+
+- add amplitude percentages and call the result dB or acoustic loudness;
+- claim clipping without measuring rendered audio;
+- infer universal comfort or quality;
+- promise focus, sleep, healing, drug-like effects, consciousness changes, or brain synchronization;
+- treat frequency-to-mental-state associations as guaranteed facts.
+
+Mention headphones for binaural content. Add brief listening-safety advice only when the content or claims make it relevant.
+
+## Optionally inspect rendered audio
+
+Do this only when the user explicitly requests deeper audio analysis.
+
+1. Validate the SPSQ first.
+2. Create a uniquely named temporary directory.
+3. Render to an explicit WAV path inside that directory; never use the CLI's default output beside the source.
+4. If available, use `ffprobe` for duration, channels, and sample rate, and `ffmpeg` analysis filters for measured peak or loudness indicators.
+5. Report the exact commands and distinguish measured results from interpretation.
+6. Treat samples at or near full scale as evidence to investigate, not automatic proof of audible clipping.
+7. Remove only the temporary directory created for this review.
+
+If rendering or inspection tools are unavailable, retain the static review and state which deeper measurements could not be made.
+
+## Deliver the report
+
+Follow [references/report-format.md](references/report-format.md). Lead with the verdict and validation result, then present findings by severity, concise preset and timeline tables, sound analysis, artistic observations, and prioritized recommendations.
+
+For batch review, add an overall summary and one compact subsection per file. Do not repeat generic explanations; define a recurring issue once and reference it.
+
+Always finish with:
+
+- whether validation ran and passed for each file;
+- which dependencies or media could not be inspected;
+- confirmation that no source file was modified;
+- static-analysis limitations;
+- `$create-spsq` guidance only when the user requested an applied correction or new corrected version.

--- a/.agents/skills/review-spsq/agents/openai.yaml
+++ b/.agents/skills/review-spsq/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review SPSQ"
+  short_description: "Audit SynapSeq sequences and sound design"
+  default_prompt: "Use $review-spsq to audit this SynapSeq sequence and produce a technical review."

--- a/.agents/skills/review-spsq/references/report-format.md
+++ b/.agents/skills/review-spsq/references/report-format.md
@@ -1,0 +1,195 @@
+# SPSQ Review Report Format
+
+## Contents
+
+- [Finding format](#finding-format)
+- [Single-file report](#single-file-report)
+- [Batch report](#batch-report)
+- [Prioritization](#prioritization)
+- [Example report](#example-report)
+
+## Finding format
+
+Give every finding one category and a stable identifier:
+
+```text
+[E1] Critical error — file.spsq:12
+[W1] Technical warning — file.spsq:20
+[A1] Artistic observation — preset focus-high
+[S1] Optional suggestion — timeline ending
+```
+
+For each finding include:
+
+- evidence: line, command output, effective preset, or measured value;
+- consequence: why the author should care;
+- recommendation: smallest reasonable next action;
+- confidence marker when the conclusion is inferred rather than explicit.
+
+Do not repeat a finding in several sections. Refer to its identifier.
+
+## Single-file report
+
+Use this structure, omitting empty sections:
+
+```markdown
+# Review of <file>
+
+## Verdict
+
+Direct summary of validity, major risks, and overall structure.
+
+## Validation result
+
+- Command executed:
+- Exit status:
+- Result:
+- File valid: yes / no / not verified
+
+## Critical errors
+
+## Technical warnings
+
+## Sequence structure
+
+| Preset | Tracks | Beat rates | Amplitudes | Effects |
+|---|---:|---|---|---|
+
+## Timeline analysis
+
+| Start | Preset | Approx. duration | Transition | Observation |
+|---|---|---:|---|---|
+
+## Sound analysis
+
+## Artistic observations
+
+## Optional suggestions
+
+## Prioritized recommendations
+
+1. Essential corrections.
+2. Important improvements.
+3. Optional experiments.
+
+## Limitations
+
+- Uninspected dependencies or media.
+- Static-analysis boundaries.
+
+No source files were modified.
+```
+
+When validation does not run, write `File valid: not verified`; never infer “yes” from manual inspection alone.
+
+When the user asks for applied corrections, add one concise note after recommendations:
+
+> This review is read-only. No file was changed. Use `$create-spsq` to create a new corrected version from this source.
+
+## Batch report
+
+Start with:
+
+```markdown
+# SPSQ batch review
+
+## Overall summary
+
+| File | Validation | Critical | Warnings | Artistic | Suggestions |
+|---|---|---:|---:|---:|---:|
+```
+
+Then add one compact section per file, sorted by path:
+
+```markdown
+## path/to/file.spsq
+
+- Verdict:
+- Validation command and status:
+- Critical findings:
+- Main technical risks:
+- Highest-priority recommendation:
+```
+
+Expand only findings specific to that file. Define a recurring issue once, assign it an identifier such as `[COMMON-W1]`, and reference it from subsequent files.
+
+End with ordered cross-file priorities and confirm that no source was modified.
+
+## Prioritization
+
+Order recommendations:
+
+1. validator failures and broken dependencies;
+2. valid but unexpected engine behavior;
+3. high-impact structural or sound-design risks;
+4. responsible-language corrections;
+5. optional artistic refinements.
+
+Do not automatically prioritize minimalism, low track count, or one particular entrainment method.
+
+## Example report
+
+```markdown
+# Review of psychedelic-journey.spsq
+
+## Verdict
+
+The sequence is structurally dense and intentionally animated. Validation
+passes, but two settings that resemble intended options are commented out,
+and the simultaneous stereo motion deserves a controlled listening test.
+
+## Validation result
+
+- Command executed: `synapseq -test psychedelic-journey.spsq`
+- Exit status: `0`
+- Result: `Sequence is valid.`
+- File valid: yes
+
+## Technical warnings
+
+[W1] Lines 2–3 contain `# @samplerate 48000` and `# @volume 65`.
+They are comments, so SynapSeq uses its defaults of 44100 Hz and volume 100.
+If the comments were intended as active settings, the rendered result will
+not match that intention.
+
+[W2] All four active tracks use movement effects in `journey-peak`.
+This is valid, but competing pan, modulation, and doppler motion may make the
+stereo field feel continuously occupied.
+
+## Sequence structure
+
+| Preset | Tracks | Beat rates | Amplitudes | Effects |
+|---|---:|---|---|---|
+| journey-base | 3 | binaural 7 Hz | 12, 8, 10 | pan, modulation |
+| journey-peak | 4 | binaural 12 Hz, isochronic 6 Hz | 14, 10, 12, 8 | pan, modulation, doppler |
+
+## Timeline analysis
+
+| Start | Preset | Approx. duration | Transition | Observation |
+|---|---|---:|---|---|
+| 00:00:00 | silence | 00:00:30 | smooth | Gradual entrance |
+| 00:00:30 | journey-base | 00:07:30 | smooth | Long controlled development |
+| 00:08:00 | journey-peak | 00:04:00 | steady | Densest phase |
+| 00:12:00 | journey-base | 00:02:30 | smooth | Returns to the base texture |
+| 00:14:30 | journey-base | 00:00:30 | smooth | Explicit final fade |
+| 00:15:00 | silence | terminal | — | End marker |
+
+## Artistic observations
+
+[A1] The dense central phase is consistent with the psychedelic identity.
+Its complexity is a defining characteristic, not an error.
+
+## Optional suggestions
+
+[S1] Consider testing a short grounding preset with lower amplitudes and one
+stable, non-moving layer before the final return. This would preserve the
+identity while increasing contrast.
+
+## Prioritized recommendations
+
+1. Decide whether the commented sample-rate and volume lines should be active.
+2. Audition the peak at low volume and verify stereo clarity.
+3. Optionally prototype a grounding phase as a separate new sequence.
+
+No source files were modified.
+```

--- a/.agents/skills/review-spsq/references/review-checklist.md
+++ b/.agents/skills/review-spsq/references/review-checklist.md
@@ -1,0 +1,190 @@
+# SPSQ Technical Review Checklist
+
+## Contents
+
+- [Evidence order](#evidence-order)
+- [Syntax and placement](#syntax-and-placement)
+- [Options and dependencies](#options-and-dependencies)
+- [Presets and inheritance](#presets-and-inheritance)
+- [Tracks and values](#tracks-and-values)
+- [Timeline semantics](#timeline-semantics)
+- [Structural quality](#structural-quality)
+- [Common valid-but-surprising behavior](#common-valid-but-surprising-behavior)
+
+## Evidence order
+
+Use evidence in this order:
+
+1. current parser and sequence-builder diagnostics;
+2. `docs/SYNTAX.md`;
+3. bundled review references;
+4. comments, names, and apparent author intent.
+
+Never downgrade a validator failure to an artistic preference. Never promote an inference into an objective error.
+
+## Syntax and placement
+
+Check:
+
+- the file is line-oriented and contains no assumed quoted-string syntax;
+- options start with `@`, appear at top level, and precede presets or timeline content;
+- lines resembling `# @option` are comments, not active options;
+- presets and timeline entries are top-level;
+- tracks and overrides use exactly two ASCII spaces;
+- no track or override appears before a preset or after the timeline begins;
+- names begin with an ASCII letter, use only letters, digits, `_`, or `-`, and remain within 20 characters;
+- `silence` is not redefined;
+- numeric tokens are ordinary decimals, not scientific notation, `NaN`, or `Inf`;
+- only documented keywords, effects, waveforms, transitions, and track forms are used;
+- token order matches the accepted track form.
+
+Comments beginning with `##` are retained as sequence metadata. Ordinary `#` comments are ignored structurally.
+
+## Options and dependencies
+
+Accepted options are:
+
+- `@samplerate INTEGER`;
+- `@volume INTEGER`;
+- `@ambiance NAME [PATH-OR-URL]`;
+- `@music NAME [PATH-OR-URL]`;
+- `@extends PATH-OR-URL`.
+
+Check:
+
+- sample rate is a positive integer;
+- volume is `0` through `100`;
+- resource names are valid and unique where required;
+- every ambiance/music track references a declaration;
+- every declaration that appears intended for playback is actually referenced;
+- local paths are relative, use `/`, contain no `..`, spaces, backslashes, roots, drive prefixes, or extensions;
+- local ambiance resolves `.wav` before `.mp3`;
+- local music resolves `.mp3` before `.wav`;
+- local extends resolves to `.spsc`;
+- remote resources identify or serve WAV/MP3 where validation can verify them;
+- dependencies exist and are readable.
+
+An `.spsc` may contain options and presets but no timeline or nested `@extends`. Do not report a declared-but-unused ambiance or music resource as invalid; classify it as an efficiency warning.
+
+## Presets and inheritance
+
+Check:
+
+- preset names are unique;
+- normal presets contain at least one direct or inherited track;
+- template presets are used only as inheritance sources;
+- a timeline never references a template;
+- `from` references an earlier template;
+- inherited presets declare overrides, never new tracks;
+- templates contain tracks, not overrides;
+- override indexes exist in the inherited layout;
+- override kinds match the inherited track and effect;
+- relative numeric overrides use a leading `+` or `-`;
+- waveform overrides use an absolute waveform keyword;
+- user presets remain within the engine limit;
+- direct presets remain within 16 channels;
+- current override indexes remain within `1` through `15`.
+
+Resolve inherited values before reviewing effective amplitude, beat rates, effects, or channel compatibility.
+
+Look for valid but questionable structure:
+
+- templates with no derived presets;
+- templates used by only one trivial variant;
+- multiple direct presets with substantial identical multi-track layouts;
+- presets never used by the timeline or inheritance;
+- derived presets whose many overrides obscure rather than reduce duplication;
+- redundant presets with identical effective channel states.
+
+These are warnings or optional refactoring suggestions, not syntax errors.
+
+## Tracks and values
+
+Supported source families:
+
+- `tone`;
+- `noise`;
+- `ambiance`;
+- `music`.
+
+Tone may be pure, binaural, monaural, or isochronic. Waveforms are `sine`, `square`, `triangle`, and `sawtooth`.
+
+Effects:
+
+- tone: `pan`, `modulation`, `doppler`;
+- noise: `pan`, `modulation`;
+- ambiance/music: `pan`, `modulation`.
+
+Check:
+
+- carrier and beat/resonance values are non-negative;
+- binaural and monaural beats remain below twice the carrier;
+- amplitude and effect intensity are `0` through `100`;
+- noise smoothness is `0` through `100`;
+- effect values are non-negative;
+- `smooth` appears only on noise and before any effect;
+- effect is followed by its value, `intensity`, then amplitude;
+- external resource names match declarations.
+
+Do not invent unsupported codecs, effects, source types, or implied parameters.
+
+## Timeline semantics
+
+Timeline form:
+
+```text
+HH:MM:SS PRESET [TRANSITION [STEPS]]
+```
+
+Check:
+
+- the first entry is exactly `00:00:00`;
+- each field uses two digits and valid hour/minute/second ranges;
+- timestamps strictly increase;
+- at least two entries exist;
+- every referenced preset exists and is playable;
+- transitions are `steady`, `ease-in`, `ease-out`, or `smooth`;
+- steps are non-negative, at most 12, and fit the interval;
+- total duration equals the final timestamp.
+
+The transition and steps on an entry control the interval toward the next entry. Steps create `2 × steps + 1` alternating legs, each requiring at least five seconds.
+
+Review:
+
+- duration of every interval;
+- whether a first `silence` produces an intentional entrance;
+- whether an active preset repeated before final `silence` intentionally starts a late fade;
+- whether final `silence` provides an intentional landing;
+- consecutive or intermediate silence that adds no useful behavior;
+- transitions too short to make large parameter changes feel controlled;
+- steps that add unnecessary oscillation;
+- long holds with no changing parameters;
+- abrupt growth without later release;
+- comments or phase names contradicted by the actual timeline.
+
+## Structural quality
+
+Compare effective tracks by channel order between every consecutive pair of presets.
+
+Compatible source and effect layouts interpolate. Incompatible source types, effect types, ambiance names, or music names trigger automatic per-channel boundary crossfades of up to 30 seconds on each available side. Active/off boundaries receive equivalent fades.
+
+Check:
+
+- whether track ordering aligns intended counterparts;
+- whether an automatic crossfade is expected or accidental;
+- whether source changes are masked by short neighboring periods;
+- whether the same effective preset repeats with no parameter evolution;
+- whether a repeated preset instead serves a valid hold or fade marker;
+- whether unused channel slots alternate active/off;
+- whether unnecessary preset duplication obscures the narrative.
+
+## Common valid-but-surprising behavior
+
+- Commented options do not apply; defaults may make the file valid anyway.
+- Two identical timeline states do not evolve merely because a transition keyword is present.
+- A transition belongs to the interval after the line where it is written.
+- Music becomes silent when its finite file ends; the SPSQ timeline may continue.
+- Ambiance loops and may expose MP3 padding at loop points.
+- A source/effect mismatch crossfades instead of interpolating parameters.
+- Amplitude is a control percentage, not dB SPL.
+- A syntactically valid combination can still be dense, masked, abrupt, or artistically incoherent.

--- a/.agents/skills/review-spsq/references/sound-design-guidelines.md
+++ b/.agents/skills/review-spsq/references/sound-design-guidelines.md
@@ -1,0 +1,166 @@
+# SPSQ Sound and Composition Review
+
+## Contents
+
+- [Review stance](#review-stance)
+- [Layer density](#layer-density)
+- [Tonal and rhythmic interaction](#tonal-and-rhythmic-interaction)
+- [Noise, effects, and stereo motion](#noise-effects-and-stereo-motion)
+- [Temporal narrative](#temporal-narrative)
+- [Responsible positioning](#responsible-positioning)
+- [Limits of static analysis](#limits-of-static-analysis)
+- [Optional rendered-audio review](#optional-rendered-audio-review)
+
+## Review stance
+
+Describe consequences before recommending changes. Distinguish:
+
+- **fact**: directly declared or measured;
+- **engine behavior**: established by parser, builder, or renderer;
+- **inference**: likely intent suggested by names or comments;
+- **preference**: one plausible artistic direction.
+
+Do not define one ideal sound. A sparse meditation piece and a deliberately dense psychedelic piece require different judgments. Preserve the declared identity and ask what the complexity contributes.
+
+## Layer density
+
+For each effective preset, count:
+
+- active tracks;
+- tone-based tracks;
+- simultaneous binaural, monaural, and isochronic methods;
+- noise, ambiance, and music beds;
+- animated tracks and effect types.
+
+Several moderate amplitude values can still produce a dense mix. Do not sum amplitudes and call the result loudness, headroom, dB, or clipping.
+
+Flag as a technical warning when layers are likely to compete for the same perceptual role, especially when:
+
+- several tonal carriers occupy nearby ranges;
+- several pulse methods compete simultaneously;
+- broad noise or external audio may mask quiet tones;
+- every layer moves and no stable reference remains;
+- many state changes occur in a short interval.
+
+Classify deliberate density as an artistic observation when comments and structure support it. Offer simplification only as an optional experiment.
+
+## Tonal and rhythmic interaction
+
+Review:
+
+- nearby carriers that may produce complex beating or masking;
+- multiple binaural beat rates whose stereo differences compete;
+- simultaneous binaural, monaural, and isochronic rhythms;
+- carrier movement combined with doppler movement;
+- high contrast between consecutive beat rates;
+- square and sawtooth waveforms, which contain stronger harmonics than sine;
+- long exposure to prominent pulsing or bright carriers.
+
+Do not claim a carrier is universally unsafe or uncomfortable from its number alone. Use cautious language such as “potentially prominent,” “may feel bright,” or “worth auditioning at low level.”
+
+Binaural content is meaningfully evaluated with stereo headphones. Monaural and isochronic pulses are physically present in the signal and may sound more explicit.
+
+## Noise, effects, and stereo motion
+
+Noise character:
+
+- white is brightest;
+- pink is more perceptually balanced;
+- brown emphasizes lower frequencies;
+- noise `smooth` changes short-term roughness, not color.
+
+Review whether noise stabilizes, masks, or overwhelms tonal detail. A high noise smoothness value does not guarantee softness if amplitude and other layers remain prominent.
+
+Effects:
+
+- `pan` moves stereo position;
+- `modulation` varies amplitude;
+- `doppler` adds pitch motion to tone tracks.
+
+Multiple simultaneous pan movements can occupy the stereo field. Multiple modulation effects can make the mix breathe or pulse competitively. Doppler plus carrier/beat interpolation can create compound pitch motion.
+
+Do not report simultaneous effects as wrong. Explain the likely complexity and whether a stable anchor remains.
+
+## Temporal narrative
+
+Treat the timeline as a sequence of intentions:
+
+1. entrance;
+2. establishment;
+3. development;
+4. peak or central state when relevant;
+5. release;
+6. landing.
+
+Not every sequence needs all six. Judge them against comments, names, duration, and stated purpose.
+
+Review:
+
+- whether the opening is immediate or faded;
+- whether phase lengths are proportionate to their role;
+- whether the middle evolves or holds;
+- whether contrast is perceptible but controlled;
+- whether intensity rises without release;
+- whether large parameter changes have enough time;
+- whether steps reinforce or distract from the arc;
+- whether the last active state has time to settle;
+- whether final silence creates a fade or merely follows an already silent span.
+
+A long static period may be monotonous, meditative, stabilizing, or deliberately suspended. State the duration and absence of parameter motion first; label the artistic meaning as inference.
+
+## Responsible positioning
+
+Inspect `#` and `##` comments, preset names, and accompanying user descriptions for claims of:
+
+- cure, treatment, prevention, or diagnosis;
+- guaranteed sleep or focus;
+- guaranteed brain synchronization;
+- guaranteed altered consciousness;
+- reproduction of drug effects;
+- specific neurological, psychological, or medical outcomes.
+
+Recommend factual creative language: “designed for,” “intended as,” “explores,” or “may feel.” SynapSeq is a creative and experimental audio tool, not a medical device.
+
+When relevant, keep advice brief:
+
+- listen at a comfortable level;
+- use stereo headphones for binaural material;
+- do not listen during driving or attention-critical activity;
+- stop if discomfort occurs.
+
+Do not turn an ordinary report into a legal disclaimer.
+
+## Limits of static analysis
+
+Static SPSQ review cannot establish:
+
+- perceived quality for every listener;
+- real acoustic level or dB SPL;
+- device, amplifier, or headphone behavior;
+- clipping in rendered samples;
+- actual content of uninspected ambiance/music;
+- seamlessness of external loops;
+- medical, cognitive, or brain-state outcomes.
+
+Recommend low-volume critical listening when sound quality matters. Label every unmeasured conclusion accordingly.
+
+## Optional rendered-audio review
+
+Perform only on explicit request and after `-test` succeeds.
+
+Render safely:
+
+1. create a unique temporary directory;
+2. choose an explicit WAV path inside it;
+3. run `synapseq INPUT OUTPUT.wav` or the available repository fallback;
+4. never rely on the default output name beside the source.
+
+If available, use:
+
+- `ffprobe` to measure duration, channel count, codec, and sample rate;
+- `ffmpeg` `astats` for sample peaks and other signal statistics;
+- `ffmpeg` `ebur128` for integrated and momentary loudness indicators.
+
+Report exact commands and preserve tool units. A peak at or extremely close to full scale warrants investigation; it is not by itself proof that every listener will hear distortion. Loudness measurements are properties of the rendered file, not dB SPL at the ear.
+
+Do not play audio automatically. Clean up only the exact temporary directory created for the review.

--- a/.agents/skills/review-spsq/scripts/validate.sh
+++ b/.agents/skills/review-spsq/scripts/validate.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -u
+
+if (( $# == 0 )); then
+  printf 'usage: %s FILE.spsq [FILE.spsq ...]\n' "$0" >&2
+  exit 2
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd -- "${script_dir}/../../../.." && pwd -P)"
+
+validator_kind=""
+validator_path=""
+
+if [[ -x "${repo_root}/bin/synapseq" ]]; then
+  validator_kind="binary"
+  validator_path="${repo_root}/bin/synapseq"
+elif command -v synapseq >/dev/null 2>&1; then
+  validator_kind="binary"
+  validator_path="$(command -v synapseq)"
+elif command -v go >/dev/null 2>&1 && [[ -f "${repo_root}/go.mod" ]]; then
+  validator_kind="go-run"
+else
+  printf 'error: no SynapSeq validator is available\n' >&2
+  printf 'tried: %s, installed synapseq, and repository go run fallback\n' \
+    "${repo_root}/bin/synapseq" >&2
+  exit 127
+fi
+
+overall_status=0
+
+for input_path in "$@"; do
+  printf '=== %s ===\n' "$input_path"
+
+  if [[ ! -f "$input_path" ]]; then
+    printf 'command: not run\n'
+    printf 'error: file not found or not a regular file\n' >&2
+    printf 'status: 2\n'
+    overall_status=1
+    continue
+  fi
+
+  input_dir="$(cd -- "$(dirname -- "$input_path")" && pwd -P)"
+  input_abs="${input_dir}/$(basename -- "$input_path")"
+
+  if [[ "$validator_kind" == "binary" ]]; then
+    printf 'command: %q -test %q\n' "$validator_path" "$input_abs"
+    if "$validator_path" -test "$input_abs"; then
+      command_status=0
+    else
+      command_status=$?
+    fi
+  else
+    printf 'command: (cd %q && go run ./cmd/synapseq -test %q)\n' \
+      "$repo_root" "$input_abs"
+    if (cd -- "$repo_root" && go run ./cmd/synapseq -test "$input_abs"); then
+      command_status=0
+    else
+      command_status=$?
+    fi
+  fi
+
+  printf 'status: %d\n' "$command_status"
+  if (( command_status != 0 )); then
+    overall_status=1
+  fi
+done
+
+exit "$overall_status"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <p align="center">
   <a href="https://skills.sh/synapseq-foundation/synapseq/create-spsq"><img src="https://img.shields.io/badge/skills.sh-create--spsq-000000?logo=vercel&logoColor=white" alt="create-spsq on skills.sh"></a>
   <a href="https://skills.sh/synapseq-foundation/synapseq/explain-spsq"><img src="https://img.shields.io/badge/skills.sh-explain--spsq-000000?logo=vercel&logoColor=white" alt="explain-spsq on skills.sh"></a>
+  <a href="https://skills.sh/synapseq-foundation/synapseq/review-spsq"><img src="https://img.shields.io/badge/skills.sh-review--spsq-000000?logo=vercel&logoColor=white" alt="review-spsq on skills.sh"></a>
 </p>
 
 <p align="center"><strong>SynapSeq - Text-Driven Audio Sequencer for Brainwave Entrainment</strong></p>
@@ -78,16 +79,18 @@ The result is a repeatable audio session generated from the text definition. See
 
 ## Use SPSQ With AI Agents
 
-SynapSeq publishes two complementary skills for AI coding agents:
+SynapSeq publishes three complementary skills for AI coding agents:
 
 - [`create-spsq`](https://skills.sh/synapseq-foundation/synapseq/create-spsq) creates and validates new `.spsq` sequences, either from scratch or from existing read-only references.
 - [`explain-spsq`](https://skills.sh/synapseq-foundation/synapseq/explain-spsq) explains supplied sequences and teaches SPSQ syntax without changing files.
+- [`review-spsq`](https://skills.sh/synapseq-foundation/synapseq/review-spsq) audits existing sequences, validates them, and reports technical and artistic findings without changing files.
 
-Install either skill interactively from its `skills.sh` source:
+Install any skill interactively from its `skills.sh` source:
 
 ```bash
 npx skills add https://github.com/synapseq-foundation/synapseq --skill create-spsq
 npx skills add https://github.com/synapseq-foundation/synapseq --skill explain-spsq
+npx skills add https://github.com/synapseq-foundation/synapseq --skill review-spsq
 ```
 
 To install a skill globally for a specific agent without prompts, use the corresponding command:
@@ -96,10 +99,12 @@ To install a skill globally for a specific agent without prompts, use the corres
 # Codex
 npx skills add https://github.com/synapseq-foundation/synapseq --skill create-spsq --global --agent codex --yes
 npx skills add https://github.com/synapseq-foundation/synapseq --skill explain-spsq --global --agent codex --yes
+npx skills add https://github.com/synapseq-foundation/synapseq --skill review-spsq --global --agent codex --yes
 
 # Claude Code
 npx skills add https://github.com/synapseq-foundation/synapseq --skill create-spsq --global --agent claude-code --yes
 npx skills add https://github.com/synapseq-foundation/synapseq --skill explain-spsq --global --agent claude-code --yes
+npx skills add https://github.com/synapseq-foundation/synapseq --skill review-spsq --global --agent claude-code --yes
 ```
 
 Omit `--global` to install the skill only in the current project.
@@ -111,6 +116,7 @@ Mention the skill explicitly according to the task:
 ```text
 $create-spsq Create a 20-minute relaxation sequence with a smooth binaural fade-in and fade-out.
 $explain-spsq Explain the presets, tracks, and timeline in focus.spsq.
+$review-spsq Audit focus.spsq and report technical, structural, and artistic findings.
 ```
 
 You can also describe the task normally; Codex may select the skill automatically when the request matches its description.
@@ -122,6 +128,7 @@ Invoke the installed skill as a slash command:
 ```text
 /create-spsq Create a 20-minute relaxation sequence with a smooth binaural fade-in and fade-out.
 /explain-spsq Explain the presets, tracks, and timeline in focus.spsq.
+/review-spsq Audit focus.spsq and report technical, structural, and artistic findings.
 ```
 
 Claude Code can also load a skill automatically when a request matches its description. Explicit invocation is the most predictable option for both agents. Install SynapSeq using the [Quick Start](#quick-start) instructions when the agent needs to validate a local file with `synapseq -test`.


### PR DESCRIPTION
## Summary

- add the read-only `review-spsq` technical and sound-design audit skill
- include deterministic single-file and batch validation tooling
- add progressive references for objective checks, sound review, and report formatting
- route creation, explanation, and review requests across the three SPSQ skills
- document and publish `review-spsq` alongside the existing skills

## Validation

- skill `quick_validate.py` and `openai.yaml` checks
- `bash -n` and validator tests for valid, invalid, missing, batch, and spaced paths
- `git diff --check`
- `make test`
- independent forward-tests for dense review, mixed batch review, correction refusal, dependency handling, and opt-in rendered WAV analysis
- source hashes remained unchanged and temporary WAV artifacts were cleaned up