### PR TITLE
feat: align SynapSeq agent skills

### DIFF
--- a/.agents/skills/create-spsq/SKILL.md
+++ b/.agents/skills/create-spsq/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: create-spsq
-description: Create and validate new SynapSeq `.spsq` brainwave-entrainment sequence files. Use when an agent needs to translate a listening goal into a new sequence or create a new adapted, corrected, or extended sequence from an existing read-only `.spsq` reference and its `.spsc` dependencies. Never edit, overwrite, move, or delete an existing sequence or dependency. Use `$review-spsq` for technical audit or validation of existing files and `$explain-spsq` for syntax lessons or didactic walkthroughs.
+description: Create new SynapSeq `.spsq` sequence files from a user description or from an existing sequence used as a read-only reference. Use when the task requires a new file, variant, adaptation, or revised version. Validate every new file, but never modify an existing `.spsq`, `.spsc`, dependency, or occupied destination in place. Use `review-spsq` for critical audits and `explain-spsq` for teaching or clarification.
 ---
 
 # Create SPSQ Sequences
 
 Create syntactically valid, listenable SynapSeq sequences while keeping claims about their effects modest. Reply in the user's language even though the DSL keywords and this skill are in English.
 
+This is the only SynapSeq skill authorized to create complete `.spsq` files. It creates from scratch or derives a new version from read-only material; it never edits an artifact in place.
+
 ## Load the language reference
 
 Read [references/spsq-language.md](references/spsq-language.md) before writing a new sequence. It contains the accepted line forms, validated ranges, timeline semantics, and examples.
 
 When working inside the SynapSeq repository, consult `docs/SYNTAX.md` and the parser only if the bundled reference appears stale or the requested feature is not covered. Treat the current parser and sequence builder as authoritative.
+
+Read [references/handoff-contract.md](references/handoff-contract.md) only when consuming or producing a real handoff to another skill.
+
+## Route by primary intent
+
+Use this skill when the main action is create, generate, produce, assemble, recreate, transform into another file, create a variant, or apply recommendations as a new version.
+
+- For review, audit, quality assessment, risk identification, or validation of an existing file, recommend `review-spsq`.
+- For explanation, teaching, line interpretation, or feature comparison, recommend `explain-spsq`.
+- For a compound request that requires review findings before creation, hand off to `review-spsq` unless concrete recommendations are already supplied. When recommendations are supplied, create the new file without recreating the audit or extended lesson.
 
 ## Gather the intent
 
@@ -23,6 +35,8 @@ Extract these requirements from the request:
 - available local paths or URLs for ambiance and music;
 - desired output path;
 - any existing `.spsq` supplied as a read-only design or content reference.
+
+When the request contains a `synapseq_task` handoff targeted at `create-spsq`, treat its natural-language prompt as authoritative and the YAML as structured supporting context. Verify the referenced files and requested destination instead of assuming they exist. Preserve the stated objective, constraints, and `preserve` items, but decide the concrete valid SPSQ implementation here.
 
 For a vague request such as “make a focus sequence,” ask only for the missing essentials: duration and whether the user prefers a method or delegates that choice. Ask about headphones only when binaural is a likely choice. Do not block on optional details once those essentials are known.
 
@@ -41,13 +55,15 @@ Treat focus, sleep, relaxation, meditation, and similar terms as creative listen
 
 Do not invent ambiance or music assets. Use only paths, URLs, or named resources supplied by the user or already present in the sequence and its `.spsc` dependencies. If a requested external layer has no source, ask for it or omit that layer and say so.
 
-## Protect existing files
+## Enforce immutable inputs
 
-Treat every existing file as read-only, including source `.spsq` files, `.spsc` dependencies, ambiance, music, and any path already occupying the requested destination. Never overwrite, edit, format, rename, move, delete, change permissions on, or otherwise mutate them.
+An existing artifact means any path present before this task begins. Treat every such path as read-only, including source `.spsq` files, `.spsc` dependencies, ambiance, music, and occupied destinations.
+
+Never overwrite, edit, format, rename, move, delete, change permissions on, or otherwise mutate an existing artifact. Do not use in-place mutation commands such as `sed -i`, `perl -pi`, `truncate`, `rm`, or `mv` on a source, and do not redirect output over an existing path.
 
 If the user asks to edit, change, adapt, extend, or repair an existing `.spsq`, interpret the request as creating a new derived `.spsq`. Read the entire source and every accessible local `.spsc` it extends, but apply the requested changes only to the new output. Preserve unrelated options, comments, resource declarations, preset names, track order, and formatting when copying material into the derivative.
 
-If the user asks only to audit, review, diagnose, or validate an existing file, recommend `$review-spsq`. If the user asks for a syntax lesson or didactic walkthrough, recommend `$explain-spsq`.
+If the user asks only to audit, review, diagnose, or validate an existing file, finish with a portable handoff to `review-spsq` rather than doing a reduced review. If the user asks only for a syntax lesson or didactic walkthrough, hand off to `explain-spsq`.
 
 ## Choose a new output path
 
@@ -58,14 +74,16 @@ For a sequence derived from an existing file:
 1. Use an explicitly requested output only when it differs from the source and does not already exist.
 2. If the requested output is the source or any other existing path, do not write; ask for a new path.
 3. If no output is requested, create it beside the source so relative `@extends`, ambiance, and music paths retain their meaning.
-4. Derive a short lowercase hyphenated name from the requested change. If that name exists, add `-2`, `-3`, and so on before `.spsq` until the path is unused.
+4. Prefer `<source-stem>-v2.spsq`; if the source already ends in `-vN`, increment `N`. If that path exists, continue to the next unused version. A descriptive lowercase hyphenated name requested by the user is also acceptable when unused.
 5. If the user requests another directory, verify that every relative dependency remains valid from the new location. If SPSQ path rules prevent that, ask for a compatible destination; do not copy or modify dependencies or media.
 
 When filesystem tools are unavailable, return one fenced `spsq` block as a new sequence and state that no file was written.
 
 ## Create the file
 
-Write only to the unused output selected above. For a derivative, make the smallest coherent change that satisfies the request and recheck channel ordering and every timeline reference after changing presets. The new output may be revised during its own creation and validation, but its read-only sources and dependencies may not.
+Recheck that the selected output is still unused immediately before writing. Write only to that reserved path. For a derivative, make the smallest coherent change that satisfies the request and recheck channel ordering and every timeline reference after changing presets.
+
+The newly reserved output may be revised during this creation-and-validation run. That exception applies only to the new output; all artifacts that existed before the task remain immutable.
 
 Use exactly two ASCII spaces for tracks and overrides. Never use quoted strings: the language tokenizes on whitespace and has no quoting syntax.
 
@@ -102,3 +120,7 @@ If validation cannot run because the CLI or referenced media is unavailable, per
 ## Deliver the result
 
 State the newly created path, whether CLI validation passed, and a concise description of the sound sources and phase progression. When a source was provided, explicitly confirm that it and its dependencies were used read-only and left unchanged. Mention headphones for binaural content. Do not restate the whole file when it was already written unless the user asks.
+
+For a derived sequence, summarize the meaningful differences from the source without turning the response into a full quality audit.
+
+After completing the new file, recommend `review-spsq` only when an independent audit has clear value, such as for a long sequence, dense layering, many effects, complex inheritance, external dependencies, or a detailed artistic brief. Recommend `explain-spsq` only when a separate didactic walkthrough was requested. For either case, emit the portable handoff contract; never assume another skill can be invoked automatically.

--- a/.agents/skills/create-spsq/agents/openai.yaml
+++ b/.agents/skills/create-spsq/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Create SPSQ"
-  short_description: "Create and validate new SynapSeq sequences"
-  default_prompt: "Use $create-spsq to create and validate a SynapSeq sequence for my listening goal."
+  short_description: "Create new SynapSeq files without overwriting"
+  default_prompt: "Use $create-spsq to create and validate a new SynapSeq sequence without modifying existing files."

--- a/.agents/skills/create-spsq/references/handoff-contract.md
+++ b/.agents/skills/create-spsq/references/handoff-contract.md
@@ -1,0 +1,164 @@
+# SynapSeq Skill Handoff Contract
+
+Read this reference only when another SynapSeq skill is genuinely responsible for a distinct next step. A handoff is textual and portable; direct skill invocation is optional and must never be assumed.
+
+## Required output
+
+Complete the current skill's responsibility before emitting one handoff. Use this natural-language section:
+
+```markdown
+## Recommended next task
+
+- Skill: `<target-skill>`
+- Reason: `<why the target owns this next step>`
+- Input files:
+  - `<path or none>`
+- Suggested output file:
+  - `<unused path or not applicable>`
+- Objective:
+  - `<concrete objective>`
+- Requirements:
+  - `<specific requirement>`
+- Constraints:
+  - `<specific constraint>`
+- Completion criteria:
+  - `<observable completion criterion>`
+```
+
+Then provide a prompt that works without prior conversation:
+
+````markdown
+## Prompt for the next skill
+
+```text
+$<target-skill> <complete, self-contained instruction>
+```
+````
+
+Finally add machine-readable supporting context:
+
+````markdown
+## Structured context
+
+```yaml
+synapseq_task:
+  source_skill: review-spsq
+  target_skill: create-spsq
+  operation: create_new_version
+  source_files:
+    - session.spsq
+  output_file: session-v2.spsq
+  objective:
+    - reduce_stereo_competition
+  requirements:
+    - remove_pan_from_peak_noise
+    - validate_with_synapseq_test
+  preserve:
+    - total_duration
+    - artistic_identity
+  changes:
+    - add_intermediate_grounding_preset
+  constraints:
+    - never_modify_source
+    - use_supported_syntax_only
+  completion_criteria:
+    - new_file_created
+    - source_file_unchanged
+    - validation_passed
+```
+````
+
+Use `null` for an inapplicable `output_file` and `[]` for an inapplicable list. Keep these operation values stable:
+
+- `create_new_sequence`
+- `create_new_version`
+- `review_existing`
+- `explain_behavior`
+
+The Markdown explanation is authoritative. YAML supplements it and must agree with it.
+
+## Portability and completeness
+
+- Name exactly one target skill: `create-spsq`, `explain-spsq`, or `review-spsq`.
+- Never target the current skill.
+- Never depend on automatic invocation, subagents, persistent context, or an orchestrator.
+- Never use vague phrases such as “apply the above,” “continue the work,” or “fix the issues found.”
+- Repeat concrete source paths, output path, requested changes, preserved characteristics, constraints, and validation expectations in the prompt.
+- Use only facts established by the current task. Do not invent command results or source details.
+- If the target skill is unavailable, the handoff must still be copyable and useful.
+
+## Loop prevention
+
+- Finish the current responsibility before recommending another skill.
+- Emit no handoff for a simple request already completed.
+- Use only one primary next skill. Mention other possibilities briefly as alternatives when necessary.
+- Do not send work back merely to repeat validation, explanation, or review already completed.
+- Do not use a handoff to avoid work within the current skill's scope.
+
+## Direction rules
+
+- `review-spsq` to `create-spsq`: include every recommended change concretely, an unused output suggestion, what must be preserved, source immutability, and validation.
+- `review-spsq` to `explain-spsq`: identify the exact valid construction, lines, and behavior needing deeper teaching; no output file.
+- `explain-spsq` to `create-spsq`: describe the complete example or new version to materialize; never ask create to infer the lesson.
+- `explain-spsq` to `review-spsq`: identify the files and requested audit dimensions; use only for a distinct critical assessment.
+- `create-spsq` to `review-spsq`: identify the new file and high-value review dimensions; use only for a sufficiently complex result.
+- `create-spsq` to `explain-spsq`: identify the new file and exact concepts to teach; use only when a separate walkthrough was requested.
+
+## Consuming a handoff
+
+Confirm that `target_skill` matches the active skill. Resolve and inspect every listed input before relying on it. Treat the natural-language prompt as authoritative if YAML and prose conflict, report the inconsistency, and do not guess about paths or desired changes. Apply the current skill's own safety and immutability rules regardless of what a handoff requests.
+
+## Example: create to review
+
+````markdown
+## Recommended next task
+
+- Skill: `review-spsq`
+- Reason: perform an independent assessment of the newly created complex composition
+- Input files:
+  - `psychedelic-journey-v2.spsq`
+- Suggested output file:
+  - not applicable
+- Objective:
+  - review progression, layers, effects, and timeline.
+- Requirements:
+  - run `synapseq -test`;
+  - distinguish errors, warnings, artistic observations, and suggestions.
+- Constraints:
+  - do not modify or create files.
+- Completion criteria:
+  - technical and compositional report produced.
+
+## Prompt for the next skill
+
+```text
+$review-spsq Review psychedelic-journey-v2.spsq. Run synapseq -test, analyze
+progression, layers, effects, and timeline, and distinguish critical errors,
+technical warnings, artistic observations, and optional suggestions. Do not
+modify or create files.
+```
+
+## Structured context
+
+```yaml
+synapseq_task:
+  source_skill: create-spsq
+  target_skill: review-spsq
+  operation: review_existing
+  source_files:
+    - psychedelic-journey-v2.spsq
+  output_file: null
+  objective:
+    - review_progression_layers_effects_and_timeline
+  requirements:
+    - validate_with_synapseq_test
+    - classify_findings_by_severity
+  preserve: []
+  changes: []
+  constraints:
+    - never_modify_source
+    - never_create_sequence
+  completion_criteria:
+    - technical_and_compositional_report_produced
+```
+````

--- a/.agents/skills/explain-spsq/SKILL.md
+++ b/.agents/skills/explain-spsq/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: explain-spsq
-description: Explain how SynapSeq `.spsq` sequences work and teach the SPSQ language without creating or editing files. Use for didactic walkthroughs of supplied sequences and questions about SPSQ syntax, semantics, tracks, inheritance, timelines, transitions, fades, or likely listening experience. Use `$review-spsq` for systematic technical audits, validation, severity-classified findings, or batch review. When the user wants a new changed or corrected file, recommend `$create-spsq`.
+description: Explain SynapSeq syntax, semantics, timeline behavior, tracks, presets, transitions, effects, dependencies, validation errors, and existing `.spsq` or `.spsc` files. Use for teaching, interpretation, comparison, and clarification. This skill is read-only and does not create or modify complete sequence files. Use `review-spsq` for critical audits and `create-spsq` for a new file or version.
 ---
 
 # Explain SPSQ Sequences
 
 Explain SPSQ as a readable audio score. Be detailed enough to teach, but adapt the depth and terminology to the user's question. Reply in the user's language even though SPSQ keywords and this skill are in English.
 
-Never create, edit, repair, or rewrite an `.spsq` or `.spsc` file. If the user asks for a change or correction, recommend `$create-spsq` to create a new file while leaving the existing material untouched. For a mixed request, explain the existing material and redirect only the new-file part.
+Never create, edit, repair, rename, move, delete, overwrite, or rewrite an `.spsq`, `.spsc`, dependency, or other project artifact. If the user asks for a change or correction, recommend `create-spsq` to create a differently named file while leaving existing material untouched. For a mixed request, complete the explanation and hand off only the distinct new-file or audit portion.
 
 ## Load the language reference
 
@@ -15,19 +15,29 @@ Read [references/spsq-language.md](references/spsq-language.md) before explainin
 
 When working inside the SynapSeq repository, consult `docs/SYNTAX.md`, `docs/HOW_IT_WORKS.md`, and the parser or sequence builder only if the bundled reference appears stale or does not cover the requested feature. Treat the current parser and sequence builder as authoritative.
 
+Read [references/handoff-contract.md](references/handoff-contract.md) only when consuming or producing a real handoff.
+
+## Route by primary intent
+
+Use this skill when the main action is explain, teach, describe, clarify, answer a question, interpret a line, compare features, or show how a documented behavior works.
+
+- For creation, adaptation, a complete example file, or a corrected version, recommend `create-spsq`.
+- For critical review, quality assessment, risk identification, comprehensive linting, or batch analysis, recommend `review-spsq`.
+- Do not hand off a focused question merely because another skill exists.
+
 ## Choose the explanation mode
 
 Use **file walkthrough** when the user supplies or points to an `.spsq` file or pastes SPSQ content. Use **language lesson** when the user asks how SPSQ syntax or one of its constructs works.
 
 If the user refers to a file that is not available, ask for the file, its path, or its contents. Do not substitute a newly invented sequence.
 
-If the user asks for a systematic audit, critical assessment, severity-classified report, validation-only check, or review of multiple files, recommend `$review-spsq`.
+If the user asks for a systematic audit, critical assessment, severity-classified report, validation-only check, or review of multiple files, use a portable handoff to `review-spsq`.
 
 ## Walk through a sequence
 
 1. Read the entire `.spsq`, preserving line numbers for references in the explanation.
-2. Follow each accessible `@extends` dependency and read the complete `.spsc`. Resolve inherited presets conceptually so the user can understand the effective tracks. Do not fetch inaccessible remote dependencies; state what could not be resolved.
-3. Validate without rendering audio. From the SynapSeq repository, prefer:
+2. Follow and read the accessible `.spsc` dependencies needed to answer the question. Resolve inherited presets conceptually when they affect the requested explanation. Do not fetch inaccessible remote dependencies; state what could not be resolved.
+3. Validate only when a diagnostic, invalid construction, or uncertain engine behavior must be explained. Do not run validation mechanically for every walkthrough. When it is needed, validate without rendering audio and prefer:
 
 ```bash
 bin/synapseq -test path/to/sequence.spsq
@@ -40,7 +50,7 @@ synapseq -test path/to/sequence.spsq
 go run ./cmd/synapseq -test path/to/sequence.spsq
 ```
 
-Run only one applicable command. Validation is evidence for the explanation, not permission to modify the file. Never render or play audio.
+Run only one applicable command. Validation is evidence for the explanation, not permission to modify the file. Preserve the relevant diagnostic faithfully. Never render or play audio.
 
 4. Explain the sequence in this order:
    - a plain-language overview of the sound and total duration;
@@ -49,9 +59,9 @@ Run only one applicable command. Validation is evidence for the explanation, not
    - what each track contributes: source, rhythm or beat, waveform, amplitude, smoothness, and effects;
    - a chronological phase table with interval duration, active preset, transition, steps, and the change toward the next entry;
    - fades, incompatible-channel crossfades, repeated presets, and the role of `silence`;
-   - the likely perceptual progression and practical listening notes.
+   - the expected perceptual progression and practical listening notes relevant to the question.
 5. Tie non-obvious claims to source line numbers or short source fragments. Distinguish explicit facts from likely intent inferred from names, comments, or parameter choices.
-6. End with validation status, unresolved dependencies, or uncertainties only when any exist.
+6. End with validation status only when validation ran, and mention unresolved dependencies or uncertainties only when they exist.
 
 Do not dump every numeric field into prose. Group stable facts in compact tables and spend detail on relationships, changes over time, and surprising semantics. In particular, make clear that a transition written on one timeline entry controls the interval leading to the next entry.
 
@@ -66,7 +76,7 @@ If validation fails:
 - distinguish parser errors from later structural or semantic validation;
 - avoid silently interpreting invalid text as if it were accepted;
 - do not propose a rewritten full file or apply a fix;
-- recommend `$create-spsq` if the user wants a new corrected file based on the read-only original.
+- use a portable handoff to `create-spsq` if the user wants a new corrected file based on the read-only original.
 
 If validation cannot run, say so briefly and perform a structural reading using the bundled reference. Do not imply that the file passed.
 
@@ -83,7 +93,7 @@ For a general syntax lesson, cover:
 5. timeline timestamps, transitions, steps, `silence`, fades, and crossfades;
 6. the difference between accepted syntax and perceptual design choices.
 
-Use short illustrative fragments when they make a rule easier to understand. Do not turn the lesson into a customized, complete sequence. If the user asks to convert the lesson into a new file, recommend `$create-spsq`.
+Use short illustrative fragments when they make a rule easier to understand. Do not turn the lesson into a customized, complete sequence. If the user asks to materialize the lesson as a new file, hand off to `create-spsq`.
 
 ## Keep claims grounded
 
@@ -101,4 +111,8 @@ Prefer a layered answer that a beginner can enter easily and an experienced user
 - use one compact timeline table when there are multiple phases;
 - explain specialized terms at first use;
 - cite relevant lines rather than reproducing the entire file;
-- mention `$create-spsq` only when the user requests a new sequence, including a new adapted or corrected version of existing read-only material.
+- mention another skill only when the user requests a distinct creation or review task outside this skill's teaching scope.
+
+Do not classify the sequence as broadly good or bad, produce severity-ranked findings, or expand a focused explanation into a full audit. You may explain a `review-spsq` report without independently repeating the review.
+
+When a distinct next step is genuinely requested, finish your explanation first, then emit one portable handoff. The prompt must repeat the relevant facts, lines, desired output, and constraints; never say only “use the explanation above.”

--- a/.agents/skills/explain-spsq/agents/openai.yaml
+++ b/.agents/skills/explain-spsq/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Explain SPSQ"
-  short_description: "Understand SynapSeq sequences and syntax"
-  default_prompt: "Use $explain-spsq to explain how this SynapSeq sequence works."
+  short_description: "Teach SynapSeq syntax and sequence behavior"
+  default_prompt: "Use $explain-spsq to explain this SynapSeq syntax or sequence behavior without modifying files."

--- a/.agents/skills/explain-spsq/references/handoff-contract.md
+++ b/.agents/skills/explain-spsq/references/handoff-contract.md
@@ -1,0 +1,171 @@
+# SynapSeq Skill Handoff Contract
+
+Read this reference only when another SynapSeq skill is genuinely responsible for a distinct next step. A handoff is textual and portable; direct skill invocation is optional and must never be assumed.
+
+## Required output
+
+Complete the current skill's responsibility before emitting one handoff. Use this natural-language section:
+
+```markdown
+## Recommended next task
+
+- Skill: `<target-skill>`
+- Reason: `<why the target owns this next step>`
+- Input files:
+  - `<path or none>`
+- Suggested output file:
+  - `<unused path or not applicable>`
+- Objective:
+  - `<concrete objective>`
+- Requirements:
+  - `<specific requirement>`
+- Constraints:
+  - `<specific constraint>`
+- Completion criteria:
+  - `<observable completion criterion>`
+```
+
+Then provide a prompt that works without prior conversation:
+
+````markdown
+## Prompt for the next skill
+
+```text
+$<target-skill> <complete, self-contained instruction>
+```
+````
+
+Finally add machine-readable supporting context:
+
+````markdown
+## Structured context
+
+```yaml
+synapseq_task:
+  source_skill: review-spsq
+  target_skill: create-spsq
+  operation: create_new_version
+  source_files:
+    - session.spsq
+  output_file: session-v2.spsq
+  objective:
+    - reduce_stereo_competition
+  requirements:
+    - remove_pan_from_peak_noise
+    - validate_with_synapseq_test
+  preserve:
+    - total_duration
+    - artistic_identity
+  changes:
+    - add_intermediate_grounding_preset
+  constraints:
+    - never_modify_source
+    - use_supported_syntax_only
+  completion_criteria:
+    - new_file_created
+    - source_file_unchanged
+    - validation_passed
+```
+````
+
+Use `null` for an inapplicable `output_file` and `[]` for an inapplicable list. Keep these operation values stable:
+
+- `create_new_sequence`
+- `create_new_version`
+- `review_existing`
+- `explain_behavior`
+
+The Markdown explanation is authoritative. YAML supplements it and must agree with it.
+
+## Portability and completeness
+
+- Name exactly one target skill: `create-spsq`, `explain-spsq`, or `review-spsq`.
+- Never target the current skill.
+- Never depend on automatic invocation, subagents, persistent context, or an orchestrator.
+- Never use vague phrases such as “apply the above,” “continue the work,” or “fix the issues found.”
+- Repeat concrete source paths, output path, requested changes, preserved characteristics, constraints, and validation expectations in the prompt.
+- Use only facts established by the current task. Do not invent command results or source details.
+- If the target skill is unavailable, the handoff must still be copyable and useful.
+
+## Loop prevention
+
+- Finish the current responsibility before recommending another skill.
+- Emit no handoff for a simple request already completed.
+- Use only one primary next skill. Mention other possibilities briefly as alternatives when necessary.
+- Do not send work back merely to repeat validation, explanation, or review already completed.
+- Do not use a handoff to avoid work within the current skill's scope.
+
+## Direction rules
+
+- `review-spsq` to `create-spsq`: include every recommended change concretely, an unused output suggestion, what must be preserved, source immutability, and validation.
+- `review-spsq` to `explain-spsq`: identify the exact valid construction, lines, and behavior needing deeper teaching; no output file.
+- `explain-spsq` to `create-spsq`: describe the complete example or new version to materialize; never ask create to infer the lesson.
+- `explain-spsq` to `review-spsq`: identify the files and requested audit dimensions; use only for a distinct critical assessment.
+- `create-spsq` to `review-spsq`: identify the new file and high-value review dimensions; use only for a sufficiently complex result.
+- `create-spsq` to `explain-spsq`: identify the new file and exact concepts to teach; use only when a separate walkthrough was requested.
+
+## Consuming a handoff
+
+Confirm that `target_skill` matches the active skill. Resolve and inspect every listed input before relying on it. Treat the natural-language prompt as authoritative if YAML and prose conflict, report the inconsistency, and do not guess about paths or desired changes. Apply the current skill's own safety and immutability rules regardless of what a handoff requests.
+
+## Example: explain to create
+
+````markdown
+## Recommended next task
+
+- Skill: `create-spsq`
+- Reason: materialize the explanation as a new valid sequence
+- Input files:
+  - none
+- Suggested output file:
+  - `transition-example.spsq`
+- Objective:
+  - create a practical demonstration of the four transitions.
+- Requirements:
+  - include `steady`, `ease-in`, `ease-out`, and `smooth`;
+  - add didactic comments;
+  - validate with `synapseq -test`.
+- Constraints:
+  - do not modify existing files;
+  - use only supported syntax.
+- Completion criteria:
+  - new file created;
+  - validation completed successfully.
+
+## Prompt for the next skill
+
+```text
+$create-spsq Create a new transition-example.spsq file that demonstrates
+steady, ease-in, ease-out, and smooth in clearly commented phases. Do not use
+or modify existing files. Use only supported syntax and validate the new file
+with synapseq -test.
+```
+
+## Structured context
+
+```yaml
+synapseq_task:
+  source_skill: explain-spsq
+  target_skill: create-spsq
+  operation: create_new_sequence
+  source_files: []
+  output_file: transition-example.spsq
+  objective:
+    - demonstrate_supported_transitions
+  requirements:
+    - include_steady
+    - include_ease_in
+    - include_ease_out
+    - include_smooth
+    - add_didactic_comments
+    - validate_with_synapseq_test
+  preserve: []
+  changes: []
+  constraints:
+    - never_modify_existing_files
+    - use_supported_syntax_only
+  completion_criteria:
+    - new_file_created
+    - validation_passed
+```
+````

--- a/.agents/skills/review-spsq/SKILL.md
+++ b/.agents/skills/review-spsq/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: review-spsq
-description: Audit existing SynapSeq `.spsq` files without modifying them. Use for technical reviews, validation, critique, directory or multi-file audits, and analysis of syntax, builder semantics, dependencies, sound structure, timeline composition, responsible claims, or likely unexpected behavior. Classify findings as critical errors, technical warnings, artistic observations, or optional suggestions. Never save corrections; recommend `$create-spsq` when the user wants a new corrected sequence.
+description: Review an existing SynapSeq `.spsq` sequence for syntax, semantic correctness, sound structure, layering, timeline progression, transitions, dependencies, responsible claims, and likely unexpected behavior. Use for audits, critical analysis, quality checks, and batch review. Produce a read-only severity-classified report and recommendations; never modify or create sequence files.
 ---
 
 # Review SPSQ Sequences
 
 Review SPSQ files as a technical auditor and thoughtful sound-design critic. Stay read-only even when the user asks to fix, improve, optimize, or apply changes. Reply in the user's language.
+
+This skill diagnoses and recommends. It never implements a correction or creates a replacement sequence.
 
 ## Load the review references
 
@@ -17,18 +19,31 @@ Read all three references before reviewing:
 
 When working inside the SynapSeq repository, also consult `README.md`, `docs/SYNTAX.md`, `docs/HOW_IT_WORKS.md`, and the parser or sequence builder when a bundled reference appears stale or incomplete. Treat the current implementation as authoritative.
 
+Read [references/handoff-contract.md](references/handoff-contract.md) only when consuming or producing a real handoff.
+
+## Route by primary intent
+
+Use this skill when the main action is review, evaluate, analyze critically, audit, verify quality, find problems, identify risks, or suggest improvements.
+
+- For a new file, variant, or applied recommendations, complete the review and hand off to `create-spsq`.
+- For a focused lesson or deeper explanation of a valid construction, hand off to `explain-spsq` only when that teaching is a distinct requested next step.
+- Include enough explanation to justify every finding; do not delegate ordinary warning explanations.
+
 ## Keep every source read-only
 
-Never create, edit, format, rename, move, delete, or change permissions on an `.spsq`, `.spsc`, ambiance, music, or other project file. Suggestions and short corrected fragments belong only in the report.
+Never create, edit, format, rename, move, delete, overwrite, or change permissions on an `.spsq`, `.spsc`, ambiance, music, or other project artifact that existed before the review. Suggestions and short corrected fragments belong only in the report. The only writable exception is an isolated temporary render created after the task begins for explicitly requested deep audio analysis; remove only that temporary artifact.
 
 If the user asks to apply corrections:
 
 1. complete the read-only review;
 2. state that no file was changed;
 3. show only the smallest useful suggested fragments;
-4. recommend `$create-spsq` to create a new corrected file from the reviewed source.
+4. choose a suggested unused output name;
+5. emit a complete portable handoff to `create-spsq`.
 
 Do not emit a complete rewritten sequence under this skill.
+
+Suggest `<source-stem>-v2.spsq` by default. If the source already ends in `-vN`, increment `N`; if that path exists, continue until the suggestion is unused. This check reserves nothing and authorizes no write.
 
 ## Resolve the review scope
 
@@ -137,4 +152,8 @@ Always finish with:
 - which dependencies or media could not be inspected;
 - confirmation that no source file was modified;
 - static-analysis limitations;
-- `$create-spsq` guidance only when the user requested an applied correction or new corrected version.
+- a portable `create-spsq` handoff when the user requested an applied correction or when a new version is the clearest useful next step.
+
+Do not add a handoff mechanically. When one is warranted, include concrete findings as changes, preserve the sequence's stated identity and valid dependencies, and require a differently named output plus `synapseq -test`. The prompt must be self-contained and must not say only “apply the recommendations above.”
+
+For a compound request such as “review, explain, and create a better version,” perform the review and explain the findings sufficiently in the report. Then produce one `create-spsq` handoff; do not create the file and do not add a redundant `explain-spsq` handoff.

--- a/.agents/skills/review-spsq/agents/openai.yaml
+++ b/.agents/skills/review-spsq/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review SPSQ"
-  short_description: "Audit SynapSeq sequences and sound design"
-  default_prompt: "Use $review-spsq to audit this SynapSeq sequence and produce a technical review."
+  short_description: "Audit existing SynapSeq files read-only"
+  default_prompt: "Use $review-spsq to audit this existing SynapSeq sequence and produce a read-only report."

--- a/.agents/skills/review-spsq/references/handoff-contract.md
+++ b/.agents/skills/review-spsq/references/handoff-contract.md
@@ -1,0 +1,109 @@
+# SynapSeq Skill Handoff Contract
+
+Read this reference only when another SynapSeq skill is genuinely responsible for a distinct next step. A handoff is textual and portable; direct skill invocation is optional and must never be assumed.
+
+## Required output
+
+Complete the current skill's responsibility before emitting one handoff. Use this natural-language section:
+
+```markdown
+## Recommended next task
+
+- Skill: `<target-skill>`
+- Reason: `<why the target owns this next step>`
+- Input files:
+  - `<path or none>`
+- Suggested output file:
+  - `<unused path or not applicable>`
+- Objective:
+  - `<concrete objective>`
+- Requirements:
+  - `<specific requirement>`
+- Constraints:
+  - `<specific constraint>`
+- Completion criteria:
+  - `<observable completion criterion>`
+```
+
+Then provide a prompt that works without prior conversation:
+
+````markdown
+## Prompt for the next skill
+
+```text
+$<target-skill> <complete, self-contained instruction>
+```
+````
+
+Finally add machine-readable supporting context:
+
+````markdown
+## Structured context
+
+```yaml
+synapseq_task:
+  source_skill: review-spsq
+  target_skill: create-spsq
+  operation: create_new_version
+  source_files:
+    - session.spsq
+  output_file: session-v2.spsq
+  objective:
+    - reduce_stereo_competition
+  requirements:
+    - remove_pan_from_peak_noise
+    - validate_with_synapseq_test
+  preserve:
+    - total_duration
+    - artistic_identity
+  changes:
+    - add_intermediate_grounding_preset
+  constraints:
+    - never_modify_source
+    - use_supported_syntax_only
+  completion_criteria:
+    - new_file_created
+    - source_file_unchanged
+    - validation_passed
+```
+````
+
+Use `null` for an inapplicable `output_file` and `[]` for an inapplicable list. Keep these operation values stable:
+
+- `create_new_sequence`
+- `create_new_version`
+- `review_existing`
+- `explain_behavior`
+
+The Markdown explanation is authoritative. YAML supplements it and must agree with it.
+
+## Portability and completeness
+
+- Name exactly one target skill: `create-spsq`, `explain-spsq`, or `review-spsq`.
+- Never target the current skill.
+- Never depend on automatic invocation, subagents, persistent context, or an orchestrator.
+- Never use vague phrases such as “apply the above,” “continue the work,” or “fix the issues found.”
+- Repeat concrete source paths, output path, requested changes, preserved characteristics, constraints, and validation expectations in the prompt.
+- Use only facts established by the current task. Do not invent command results or source details.
+- If the target skill is unavailable, the handoff must still be copyable and useful.
+
+## Loop prevention
+
+- Finish the current responsibility before recommending another skill.
+- Emit no handoff for a simple request already completed.
+- Use only one primary next skill. Mention other possibilities briefly as alternatives when necessary.
+- Do not send work back merely to repeat validation, explanation, or review already completed.
+- Do not use a handoff to avoid work within the current skill's scope.
+
+## Direction rules
+
+- `review-spsq` to `create-spsq`: include every recommended change concretely, an unused output suggestion, what must be preserved, source immutability, and validation.
+- `review-spsq` to `explain-spsq`: identify the exact valid construction, lines, and behavior needing deeper teaching; no output file.
+- `explain-spsq` to `create-spsq`: describe the complete example or new version to materialize; never ask create to infer the lesson.
+- `explain-spsq` to `review-spsq`: identify the files and requested audit dimensions; use only for a distinct critical assessment.
+- `create-spsq` to `review-spsq`: identify the new file and high-value review dimensions; use only for a sufficiently complex result.
+- `create-spsq` to `explain-spsq`: identify the new file and exact concepts to teach; use only when a separate walkthrough was requested.
+
+## Consuming a handoff
+
+Confirm that `target_skill` matches the active skill. Resolve and inspect every listed input before relying on it. Treat the natural-language prompt as authoritative if YAML and prose conflict, report the inconsistency, and do not guess about paths or desired changes. Apply the current skill's own safety and immutability rules regardless of what a handoff requests.

--- a/.agents/skills/review-spsq/references/report-format.md
+++ b/.agents/skills/review-spsq/references/report-format.md
@@ -6,6 +6,7 @@
 - [Single-file report](#single-file-report)
 - [Batch report](#batch-report)
 - [Prioritization](#prioritization)
+- [Handoff after review](#handoff-after-review)
 - [Example report](#example-report)
 
 ## Finding format
@@ -84,7 +85,9 @@ When validation does not run, write `File valid: not verified`; never infer “y
 
 When the user asks for applied corrections, add one concise note after recommendations:
 
-> This review is read-only. No file was changed. Use `$create-spsq` to create a new corrected version from this source.
+> This review is read-only. No file was changed. The handoff below describes a new version for `create-spsq`.
+
+Then append the natural-language handoff, self-contained prompt, and YAML context defined in `handoff-contract.md`.
 
 ## Batch report
 
@@ -126,6 +129,147 @@ Order recommendations:
 5. optional artistic refinements.
 
 Do not automatically prioritize minimalism, low track count, or one particular entrainment method.
+
+## Handoff after review
+
+Use no handoff when the report fully answers the request and no separate next task has clear value.
+
+When changes are recommended and the user wants them applied, target `create-spsq`. Convert findings into concrete requirements instead of referring to finding identifiers alone:
+
+````markdown
+## Recommended next task
+
+- Skill: `create-spsq`
+- Reason: create a new version that incorporates the review recommendations
+- Input files:
+  - `psychedelic-journey.spsq`
+- Suggested output file:
+  - `psychedelic-journey-v2.spsq`
+- Objective:
+  - reduce competition in the stereo field;
+  - make the final phase more progressive;
+  - preserve the psychedelic identity.
+- Requirements:
+  - remove pan from the pink noise in preset `peak`;
+  - reduce doppler intensity in preset `peak`;
+  - create an intermediate grounding phase;
+  - preserve the total duration of 25 minutes;
+  - validate the new file with `synapseq -test`.
+- Constraints:
+  - do not modify `psychedelic-journey.spsq`;
+  - preserve the binaural beats;
+  - maintain the original narrative structure;
+  - use only supported syntax.
+- Completion criteria:
+  - new file created;
+  - original file left intact;
+  - validation completed successfully.
+
+## Prompt for the next skill
+
+```text
+$create-spsq Use psychedelic-journey.spsq as a reference and create
+psychedelic-journey-v2.spsq. Preserve the total duration of 25 minutes, the
+binaural beats, narrative structure, and psychedelic identity. Remove pan from
+the pink noise in preset peak, reduce doppler intensity in that preset, and
+create an intermediate grounding phase to make the slowdown more progressive.
+Do not modify the original file. Use only supported syntax and validate the
+new file with synapseq -test.
+```
+
+## Structured context
+
+```yaml
+synapseq_task:
+  source_skill: review-spsq
+  target_skill: create-spsq
+  operation: create_new_version
+  source_files:
+    - psychedelic-journey.spsq
+  output_file: psychedelic-journey-v2.spsq
+  objective:
+    - reduce_stereo_competition
+    - improve_grounding_progression
+  requirements:
+    - remove_pan_from_peak_noise
+    - reduce_peak_doppler_intensity
+    - add_intermediate_grounding_preset
+    - preserve_25_minute_duration
+    - validate_with_synapseq_test
+  preserve:
+    - total_duration
+    - artistic_identity
+    - binaural_structure
+    - narrative_structure
+  changes:
+    - remove_pan_from_peak_noise
+    - reduce_peak_doppler_intensity
+    - add_intermediate_grounding_preset
+  constraints:
+    - never_modify_source
+    - use_supported_syntax_only
+  completion_criteria:
+    - new_file_created
+    - source_file_unchanged
+    - validation_passed
+```
+````
+
+When a valid construction deserves a separate lesson, target `explain-spsq`:
+
+````markdown
+## Recommended next task
+
+- Skill: `explain-spsq`
+- Reason: explain a valid construction in depth
+- Input files:
+  - `session.spsq`
+- Suggested output file:
+  - not applicable
+- Objective:
+  - explain why consecutive entries with the same preset do not create evolution.
+- Requirements:
+  - consider the entries at `00:20:30` and `00:24:30`;
+  - explain interpolation and the absence of parameter changes.
+- Constraints:
+  - do not modify files;
+  - do not generate a new sequence.
+- Completion criteria:
+  - behavior explained from SynapSeq syntax and engine semantics.
+
+## Prompt for the next skill
+
+```text
+$explain-spsq Read session.spsq and explain didactically why the entries at
+00:20:30 and 00:24:30, which use the same preset without changing parameters,
+do not create sonic evolution. Explain how interpolation works over that
+interval. Do not modify files or generate a new sequence.
+```
+
+## Structured context
+
+```yaml
+synapseq_task:
+  source_skill: review-spsq
+  target_skill: explain-spsq
+  operation: explain_behavior
+  source_files:
+    - session.spsq
+  output_file: null
+  objective:
+    - explain_static_repeated_preset
+  requirements:
+    - inspect_timeline_entries_00_20_30_and_00_24_30
+    - explain_interpolation_without_parameter_change
+  preserve: []
+  changes: []
+  constraints:
+    - never_modify_source
+    - never_create_sequence
+  completion_criteria:
+    - behavior_explained_from_synapseq_semantics
+```
+````
 
 ## Example report
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,39 @@ These rules must be preserved when making changes:
 5. **`internal/audio` owns synthesis and rendering** - `core` calls it, does not reimplement audio concerns
 6. **Keep audio engine concrete** - Prefer focused collaborators over abstract interfaces
 
+## SynapSeq Agent Skills
+
+The repository ships three complementary skills under `.agents/skills/`:
+
+- **`create-spsq`** creates and validates new `.spsq` files, either from scratch or from existing read-only references. It never modifies an existing `.spsq` or `.spsc` in place.
+- **`explain-spsq`** teaches SPSQ syntax and explains existing `.spsq` or `.spsc` files without creating or modifying them.
+- **`review-spsq`** validates and audits existing `.spsq` files, producing a read-only technical and compositional report.
+
+Keep their responsibilities distinct. Route creation and new versions to `create-spsq`, didactic questions to `explain-spsq`, and critical analysis to `review-spsq`.
+
+### Mandatory synchronization for SPSQ language changes
+
+Any change that affects accepted `.spsq` or `.spsc` syntax, parser behavior, builder semantics, validation rules, tracks, effects, options, inheritance, transitions, timeline behavior, or diagnostics must be reflected in the skills in the same change. A parser or language change is incomplete until the bundled skill references and workflows agree with the implementation.
+
+At minimum, review and update:
+
+1. `docs/SYNTAX.md` for grammar, placement, ranges, and validation rules;
+2. `docs/HOW_IT_WORKS.md` when audible or temporal behavior changes;
+3. `.agents/skills/create-spsq/references/spsq-language.md`;
+4. `.agents/skills/explain-spsq/references/spsq-language.md`;
+5. `.agents/skills/review-spsq/references/review-checklist.md`;
+6. each affected `SKILL.md`, plus review sound-design or report references when the change alters analysis or output guidance.
+
+Also update `README.md` when the language change affects user-facing examples or capabilities, and update `agents/openai.yaml` when a skill's routing description changes.
+
+Before completing an SPSQ language change:
+
+- add or update parser and sequence-builder tests;
+- validate representative valid and invalid `.spsq` fixtures with `synapseq -test`;
+- run `make test`;
+- run the skill-creator `quick_validate.py` check for all three skill directories;
+- verify that no skill documents syntax, ranges, effects, or behavior that the current implementation no longer supports.
+
 ## Git Workflow
 
 - **Default branch**: `main`

--- a/README.md
+++ b/README.md
@@ -81,9 +81,11 @@ The result is a repeatable audio session generated from the text definition. See
 
 SynapSeq publishes three complementary skills for AI coding agents:
 
-- [`create-spsq`](https://skills.sh/synapseq-foundation/synapseq/create-spsq) creates and validates new `.spsq` sequences, either from scratch or from existing read-only references.
-- [`explain-spsq`](https://skills.sh/synapseq-foundation/synapseq/explain-spsq) explains supplied sequences and teaches SPSQ syntax without changing files.
-- [`review-spsq`](https://skills.sh/synapseq-foundation/synapseq/review-spsq) audits existing sequences, validates them, and reports technical and artistic findings without changing files.
+- [`create-spsq`](https://skills.sh/synapseq-foundation/synapseq/create-spsq) creates and validates a new `.spsq`, either from scratch or from an existing read-only reference.
+- [`explain-spsq`](https://skills.sh/synapseq-foundation/synapseq/explain-spsq) teaches SPSQ syntax and explains existing sequences without changing files.
+- [`review-spsq`](https://skills.sh/synapseq-foundation/synapseq/review-spsq) audits existing sequences and reports technical, structural, and artistic findings without changing files.
+
+Choose by the main action: **create** a new file, **explain** how something works, or **review** an existing file critically. Only `create-spsq` writes complete sequence files, and it always uses a new path; no skill edits an existing `.spsq` or `.spsc` in place. A review that recommends changes can provide a self-contained handoff for `create-spsq`, while complex newly created sequences can optionally be handed to `review-spsq`.
 
 Install any skill interactively from its `skills.sh` source:
 


### PR DESCRIPTION
## Summary
- establish distinct create, explain, and review responsibilities
- enforce immutable existing SPSQ and SPSC artifacts
- add portable English handoff contracts and examples
- require parser and syntax changes to update all affected skills

## Validation
- make test
- quick_validate.py for all three skills
- YAML and Markdown structure checks
- forward-tests for routing, collision handling, validation, and source immutability