### PR TITLE
feat: require context for SBaGen converter

### DIFF
--- a/cmd/synapseq/dispatch.go
+++ b/cmd/synapseq/dispatch.go
@@ -51,7 +51,7 @@ func dispatchSpecialCommand(opts *cli.CLIOptions, args []string) (bool, error) {
 	case cli.SpecialCommandDoctor:
 		return true, runDoctor()
 	case cli.SpecialCommandSBG:
-		return true, runSBGConversion(args, opts.Quiet, os.Stderr, os.Stdout)
+		return true, runSBGConversion(args, opts, os.Stderr, os.Stdout)
 	default:
 		return false, nil
 	}

--- a/cmd/synapseq/sbg.go
+++ b/cmd/synapseq/sbg.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	synapseq "github.com/synapseq-foundation/synapseq/v4/core"
 	"github.com/synapseq-foundation/synapseq/v4/internal/cli"
 	"github.com/synapseq-foundation/synapseq/v4/sbg"
 )
@@ -38,7 +39,11 @@ func runSBGConversion(args []string, quiet bool, statusWriter, outputWriter io.W
 			return err
 		}
 	}
-	loaded, err := sbg.LoadFile(inputPath)
+	converter, err := sbg.New(synapseq.NewAppContext())
+	if err != nil {
+		return err
+	}
+	loaded, err := converter.LoadFile(inputPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/synapseq/sbg.go
+++ b/cmd/synapseq/sbg.go
@@ -11,14 +11,16 @@ import (
 	"path/filepath"
 	"strings"
 
-	synapseq "github.com/synapseq-foundation/synapseq/v4/core"
 	"github.com/synapseq-foundation/synapseq/v4/internal/cli"
 	"github.com/synapseq-foundation/synapseq/v4/sbg"
 )
 
 const sbgConversionWarning = "SBaGen conversion is approximate and may contain errors; review the generated SPSQ before use."
 
-func runSBGConversion(args []string, quiet bool, statusWriter, outputWriter io.Writer) error {
+func runSBGConversion(args []string, opts *cli.CLIOptions, statusWriter, outputWriter io.Writer) error {
+	if opts == nil {
+		return fmt.Errorf("CLI options are nil")
+	}
 	if len(args) < 1 || len(args) > 2 {
 		return fmt.Errorf("invalid SBaGen conversion arguments\nUsage: synapseq -sbg <file.sbg> [output.spsq]")
 	}
@@ -34,12 +36,12 @@ func runSBGConversion(args []string, quiet bool, statusWriter, outputWriter io.W
 		return fmt.Errorf("SPSQ output must use the .spsq extension: %q", outputPath)
 	}
 
-	if !quiet && statusWriter != nil {
+	if !opts.Quiet && statusWriter != nil {
 		if err := writeSBGConversionWarning(statusWriter); err != nil {
 			return err
 		}
 	}
-	converter, err := sbg.New(synapseq.NewAppContext())
+	converter, err := sbg.New(newAppContext(outputPath, statusWriter, opts))
 	if err != nil {
 		return err
 	}
@@ -58,7 +60,7 @@ func runSBGConversion(args []string, quiet bool, statusWriter, outputWriter io.W
 	if err := os.WriteFile(outputPath, content, 0o644); err != nil {
 		return fmt.Errorf("write converted sequence %q: %w", outputPath, err)
 	}
-	if !quiet && statusWriter != nil {
+	if !opts.Quiet && statusWriter != nil {
 		return writeSBGConversionSuccess(statusWriter, outputPath)
 	}
 	return nil

--- a/cmd/synapseq/sbg_test.go
+++ b/cmd/synapseq/sbg_test.go
@@ -23,7 +23,7 @@ func TestRunSBGConversionUsesDefaultOutputAndWarns(t *testing.T) {
 		t.Fatalf("write input: %v", err)
 	}
 	var status bytes.Buffer
-	if err := runSBGConversion([]string{inputPath}, false, &status, nil); err != nil {
+	if err := runSBGConversion([]string{inputPath}, &cli.CLIOptions{}, &status, nil); err != nil {
 		t.Fatalf("runSBGConversion error: %v", err)
 	}
 	if !strings.Contains(status.String(), "conversion is approximate") || !strings.Contains(status.String(), "Converted:") || !strings.Contains(status.String(), inputPath[:len(inputPath)-len(".sbg")]+".spsq") {
@@ -50,7 +50,7 @@ func TestRunSBGConversionOverwritesOutput(t *testing.T) {
 	if err := os.WriteFile(outputPath, []byte("old"), 0o600); err != nil {
 		t.Fatalf("write old output: %v", err)
 	}
-	if err := runSBGConversion([]string{inputPath, outputPath}, false, nil, nil); err != nil {
+	if err := runSBGConversion([]string{inputPath, outputPath}, &cli.CLIOptions{}, nil, nil); err != nil {
 		t.Fatalf("runSBGConversion error: %v", err)
 	}
 	content, err := os.ReadFile(outputPath)
@@ -70,7 +70,7 @@ func TestRunSBGConversionWritesToStandardOutput(t *testing.T) {
 		t.Fatalf("write input: %v", err)
 	}
 	var output bytes.Buffer
-	if err := runSBGConversion([]string{inputPath, "-"}, false, nil, &output); err != nil {
+	if err := runSBGConversion([]string{inputPath, "-"}, &cli.CLIOptions{}, nil, &output); err != nil {
 		t.Fatalf("runSBGConversion error: %v", err)
 	}
 	if !strings.Contains(output.String(), "00:00:30 alpha steady 0") {
@@ -90,7 +90,7 @@ func TestRunSBGConversionQuietSuppressesStatus(t *testing.T) {
 	}
 	var status bytes.Buffer
 	var output bytes.Buffer
-	if err := runSBGConversion([]string{inputPath, "-"}, true, &status, &output); err != nil {
+	if err := runSBGConversion([]string{inputPath, "-"}, &cli.CLIOptions{Quiet: true}, &status, &output); err != nil {
 		t.Fatalf("runSBGConversion error: %v", err)
 	}
 	if status.Len() != 0 {

--- a/cmd/synapseq/sequencehandlers.go
+++ b/cmd/synapseq/sequencehandlers.go
@@ -50,12 +50,15 @@ func prepareSequenceCommand(args []string, opts *cli.CLIOptions) (*sequenceComma
 }
 
 func loadSequenceContext(inputFile, outputFile string, verboseWriter io.Writer, opts *cli.CLIOptions) (*synapseq.LoadedContext, error) {
+	return newAppContext(outputFile, verboseWriter, opts).LoadFile(inputFile)
+}
+
+func newAppContext(outputFile string, verboseWriter io.Writer, opts *cli.CLIOptions) *synapseq.AppContext {
 	appCtx := synapseq.NewAppContext()
 	if !opts.Quiet && outputFile != "-" && verboseWriter != nil {
 		appCtx = appCtx.WithVerbose(verboseWriter, !opts.NoColor)
 	}
-
-	return appCtx.LoadFile(inputFile)
+	return appCtx
 }
 
 func runLoadedSequence(loadedCtx *synapseq.LoadedContext, outputFile, outputFormat string, opts *cli.CLIOptions) error {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ Remote is optional input infrastructure, not part of the renderer itself.
 
 ### `sbg`
 
-This public package parses supported SBaGen input and maps its structured values into the public `spsq` builder. `LoadFile` and `LoadContent` return validated `core.LoadedContext` values; the CLI writes `RawContent()` to the requested destination.
+This public package parses supported SBaGen input and maps its structured values into the public `spsq` builder. `New` receives a caller-owned `core.AppContext`, and its `LoadFile` and `LoadContent` methods return validated `core.LoadedContext` values. The CLI writes `RawContent()` to the requested destination.
 
 ### `internal/cli`
 

--- a/sbg/doc.go
+++ b/sbg/doc.go
@@ -8,14 +8,19 @@ sequences.
 
 # Overview
 
-LoadFile converts a local SBaGen file. LoadContent converts SBaGen text already
-held in memory. Both functions return a core.LoadedContext, so callers can
-inspect the generated sequence, retrieve its SPSQ representation through
+New receives the caller's core.AppContext and returns a Converter. Its LoadFile
+method converts a local SBaGen file, while LoadContent converts SBaGen text
+already held in memory. Both methods return a core.LoadedContext, so callers
+can inspect the generated sequence, retrieve its SPSQ representation through
 RawContent, or render it with the regular core API.
 
 # Example Usage
 
-	loaded, err := sbg.LoadFile("session.sbg")
+	converter, err := sbg.New(synapseq.NewAppContext())
+	if err != nil {
+		log.Fatal(err)
+	}
+	loaded, err := converter.LoadFile("session.sbg")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sbg/example_test.go
+++ b/sbg/example_test.go
@@ -9,13 +9,18 @@ import (
 	"os"
 	"path/filepath"
 
+	synapseq "github.com/synapseq-foundation/synapseq/v4/core"
 	"github.com/synapseq-foundation/synapseq/v4/sbg"
 )
 
 const exampleContent = "alpha: 300+10/20\noff: -\nNOW alpha\n+00:01:00 off\n"
 
-func ExampleLoadContent() {
-	loaded, err := sbg.LoadContent(exampleContent)
+func ExampleConverter_LoadContent() {
+	converter, err := sbg.New(synapseq.NewAppContext())
+	if err != nil {
+		panic(err)
+	}
+	loaded, err := converter.LoadContent(exampleContent)
 	if err != nil {
 		panic(err)
 	}
@@ -24,7 +29,7 @@ func ExampleLoadContent() {
 	// Output: 1m0s
 }
 
-func ExampleLoadFile() {
+func ExampleConverter_LoadFile() {
 	dir, err := os.MkdirTemp("", "synapseq-sbg-example")
 	if err != nil {
 		panic(err)
@@ -35,7 +40,11 @@ func ExampleLoadFile() {
 	if err := os.WriteFile(path, []byte(exampleContent), 0o600); err != nil {
 		panic(err)
 	}
-	loaded, err := sbg.LoadFile(path)
+	converter, err := sbg.New(synapseq.NewAppContext())
+	if err != nil {
+		panic(err)
+	}
+	loaded, err := converter.LoadFile(path)
 	if err != nil {
 		panic(err)
 	}

--- a/sbg/sbg.go
+++ b/sbg/sbg.go
@@ -16,23 +16,36 @@ import (
 	"github.com/synapseq-foundation/synapseq/v4/spsq"
 )
 
+// Converter converts SBaGen content through the provided SynapSeq application context.
+type Converter struct {
+	ctx *synapseq.AppContext
+}
+
+// New creates an SBaGen converter using ctx.
+func New(ctx *synapseq.AppContext) (*Converter, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context is nil")
+	}
+	return &Converter{ctx: ctx}, nil
+}
+
 // LoadFile converts the SBaGen sequence at path into a validated SynapSeq sequence.
-func LoadFile(path string) (*synapseq.LoadedContext, error) {
+func (c *Converter) LoadFile(path string) (*synapseq.LoadedContext, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open SBaGen file %q: %w", path, err)
 	}
 	defer file.Close()
 
-	return load(path, file)
+	return c.load(path, file)
 }
 
 // LoadContent converts in-memory SBaGen content into a validated SynapSeq sequence.
-func LoadContent(content string) (*synapseq.LoadedContext, error) {
-	return load("<content>", strings.NewReader(content))
+func (c *Converter) LoadContent(content string) (*synapseq.LoadedContext, error) {
+	return c.load("<content>", strings.NewReader(content))
 }
 
-func load(source string, reader io.Reader) (*synapseq.LoadedContext, error) {
+func (c *Converter) load(source string, reader io.Reader) (*synapseq.LoadedContext, error) {
 	parsed, err := parse(source, reader)
 	if err != nil {
 		return nil, err
@@ -41,7 +54,7 @@ func load(source string, reader io.Reader) (*synapseq.LoadedContext, error) {
 	if err != nil {
 		return nil, err
 	}
-	loaded, err := builder.Load(synapseq.NewAppContext())
+	loaded, err := builder.Load(c.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("validate converted sequence: %w", err)
 	}

--- a/sbg/sbg_test.go
+++ b/sbg/sbg_test.go
@@ -9,7 +9,25 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	synapseq "github.com/synapseq-foundation/synapseq/v4/core"
 )
+
+func newTestConverter(t *testing.T) *Converter {
+	t.Helper()
+	converter, err := New(synapseq.NewAppContext())
+	if err != nil {
+		t.Fatalf("New error: %v", err)
+	}
+	return converter
+}
+
+func TestNewRejectsNilContext(t *testing.T) {
+	converter, err := New(nil)
+	if err == nil {
+		t.Fatalf("expected error, got converter %#v", converter)
+	}
+}
 
 func TestLoadFileUsesSPSQBuilder(t *testing.T) {
 	dir := t.TempDir()
@@ -25,7 +43,7 @@ func TestLoadFileUsesSPSQBuilder(t *testing.T) {
 		t.Fatalf("write input: %v", err)
 	}
 
-	loaded, err := LoadFile(inputPath)
+	loaded, err := newTestConverter(t).LoadFile(inputPath)
 	if err != nil {
 		t.Fatalf("LoadFile error: %v", err)
 	}
@@ -55,7 +73,7 @@ func TestLoadFileNOWUsesThirtySecondFadeIn(t *testing.T) {
 		t.Fatalf("write input: %v", err)
 	}
 
-	loaded, err := LoadFile(inputPath)
+	loaded, err := newTestConverter(t).LoadFile(inputPath)
 	if err != nil {
 		t.Fatalf("LoadFile error: %v", err)
 	}
@@ -74,7 +92,7 @@ func TestLoadContentSupportsAbsoluteTimelineTimes(t *testing.T) {
 		"00:20:00 ts2 ->",
 		"00:20:30 off",
 	}, "\n")
-	loaded, err := LoadContent(input)
+	loaded, err := newTestConverter(t).LoadContent(input)
 	if err != nil {
 		t.Fatalf("LoadContent error: %v", err)
 	}
@@ -97,7 +115,7 @@ func TestLoadFileOmitsMixWithoutMusicOption(t *testing.T) {
 		t.Fatalf("write input: %v", err)
 	}
 
-	loaded, err := LoadFile(inputPath)
+	loaded, err := newTestConverter(t).LoadFile(inputPath)
 	if err != nil {
 		t.Fatalf("LoadFile error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- require a caller-owned `core.AppContext` when constructing an SBaGen converter
- expose instance `LoadFile` and `LoadContent` methods on `sbg.Converter`
- share CLI application-context construction between SPSQ and SBaGen loading

## Validation
- `make test`