### PR TITLE
fix: add FFmpeg WinGet dependency

### DIFF
--- a/.github/workflows/templates/winget.installer.yaml.tpl
+++ b/.github/workflows/templates/winget.installer.yaml.tpl
@@ -2,6 +2,9 @@ PackageIdentifier: ruanklein.synapseq
 PackageVersion: __VERSION__
 InstallerType: zip
 NestedInstallerType: portable
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Gyan.FFmpeg
 Installers:
   - Architecture: x64
     InstallerUrl: __RELEASE_BASE_URL__/synapseq-v__VERSION__-windows-amd64.zip


### PR DESCRIPTION
## Summary
- declare Gyan.FFmpeg as a package dependency in generated WinGet installer manifests

## Validation
- ruby YAML parse of .github/workflows/templates/winget.installer.yaml.tpl
- rtk git diff --check