### PR TITLE
feat: convert SBaGen sample rate options

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ When the output is omitted, SynapSeq writes a `.spsq` file alongside the source 
 
 SBaGen `-m` sources and `mix` voices convert to SPSQ music options and tracks. The music file must be inside the current working directory without `..` traversal; its extension is removed and SynapSeq resolves the resulting base as `.mp3` or `.wav`.
 
+SBaGen `-r <sample-rate>` becomes SPSQ `@samplerate`; absent `-r` values default to `44100`.
+
 > [!WARNING]
 > SBaGen conversion is experimental. More complex sequences can produce differences or conversion errors because SBaGen and SynapSeq do not have identical sound sources, transition behavior, or media support. Review and validate the generated `.spsq` before using it.
 

--- a/sbg/definition.go
+++ b/sbg/definition.go
@@ -7,6 +7,7 @@ package sbg
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -21,6 +22,23 @@ func parseMusicOption(fields []string) (string, bool, error) {
 		return fields[index+1], true, nil
 	}
 	return "", false, nil
+}
+
+func parseSampleRateOption(fields []string) (int, bool, error) {
+	for index, field := range fields {
+		if field != "-r" {
+			continue
+		}
+		if index+1 >= len(fields) {
+			return 0, true, errors.New("-r requires a sample rate")
+		}
+		sampleRate, err := strconv.Atoi(fields[index+1])
+		if err != nil {
+			return 0, true, errors.New("-r requires an integer sample rate")
+		}
+		return sampleRate, true, nil
+	}
+	return 0, false, nil
 }
 
 func validName(value string) bool {

--- a/sbg/doc.go
+++ b/sbg/doc.go
@@ -32,10 +32,12 @@ RawContent, or render it with the regular core API.
 
 Supported SBaGen voices are mapped to the corresponding SPSQ tracks. Binaural
 sign orientation is not represented by SPSQ. Spin voices are approximated with
-pink noise and a pan effect. An SBaGen -m source becomes the SPSQ music source
-named music, and each mix voice becomes a music track. Music paths must remain
-within the current directory and cannot contain parent traversal; their
-extension is removed so SynapSeq can resolve an MP3 or WAV source. SBaGen fade
-markers are accepted but converted to steady transitions.
+pink noise and a pan effect. An SBaGen -m source becomes an SPSQ music source
+named after its file base, and each mix voice becomes a music track. Music
+paths must remain within the current directory and cannot contain parent
+traversal; their extension is removed so SynapSeq can resolve an MP3 or WAV
+source. The SBaGen -r option becomes the SPSQ sample rate; it defaults to 44100
+when absent. SBaGen fade markers are accepted but converted to steady
+transitions.
 */
 package sbg

--- a/sbg/parser.go
+++ b/sbg/parser.go
@@ -13,7 +13,7 @@ import (
 )
 
 func parse(source string, reader io.Reader) (*sequence, error) {
-	result := &sequence{source: source}
+	result := &sequence{source: source, sampleRate: defaultSampleRate}
 	definitions := make(map[string]struct{})
 	var relativeBase time.Duration
 	scanner := bufio.NewScanner(reader)
@@ -37,9 +37,18 @@ func parse(source string, reader io.Reader) (*sequence, error) {
 		if err != nil {
 			return nil, lineError(source, lineNumber, err.Error())
 		}
+		sampleRate, hasSampleRate, err := parseSampleRateOption(fields)
+		if err != nil {
+			return nil, lineError(source, lineNumber, err.Error())
+		}
 		if ok {
 			result.musicPath = musicPath
 			result.musicLine = lineNumber
+		}
+		if hasSampleRate {
+			result.sampleRate = sampleRate
+		}
+		if ok || hasSampleRate {
 			continue
 		}
 

--- a/sbg/parser_test.go
+++ b/sbg/parser_test.go
@@ -26,6 +26,9 @@ func TestParseSequence(t *testing.T) {
 	if parsed.musicPath != "audio/background.mp3" || parsed.musicLine != 1 {
 		t.Fatalf("music source = %q at line %d", parsed.musicPath, parsed.musicLine)
 	}
+	if parsed.sampleRate != defaultSampleRate {
+		t.Fatalf("sample rate = %d", parsed.sampleRate)
+	}
 	if len(parsed.definitions) != 2 || len(parsed.definitions[0].voices) != 5 {
 		t.Fatalf("definitions = %#v", parsed.definitions)
 	}
@@ -60,5 +63,43 @@ func TestParseRejectsNegativeTimelineFields(t *testing.T) {
 	_, err := parse("test.sbg", strings.NewReader(input))
 	if err == nil || !strings.Contains(err.Error(), "invalid timeline time") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestParseSampleRateOption(t *testing.T) {
+	input := "-SE -r 48000 -m audio/background.mp3\nalpha: 300+10/20\nNOW alpha\n"
+	parsed, err := parse("test.sbg", strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if parsed.sampleRate != 48000 {
+		t.Fatalf("sample rate = %d", parsed.sampleRate)
+	}
+	if parsed.musicPath != "audio/background.mp3" {
+		t.Fatalf("music path = %q", parsed.musicPath)
+	}
+}
+
+func TestParseSampleRateLastOptionWins(t *testing.T) {
+	input := "-r 22050\n-r 48000\nalpha: 300+10/20\nNOW alpha\n"
+	parsed, err := parse("test.sbg", strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if parsed.sampleRate != 48000 {
+		t.Fatalf("sample rate = %d", parsed.sampleRate)
+	}
+}
+
+func TestParseRejectsInvalidSampleRateOption(t *testing.T) {
+	for _, input := range []string{
+		"-r\nalpha: 300+10/20\nNOW alpha\n",
+		"-r invalid\nalpha: 300+10/20\nNOW alpha\n",
+		"-r 999999999999999999999999999999\nalpha: 300+10/20\nNOW alpha\n",
+	} {
+		_, err := parse("test.sbg", strings.NewReader(input))
+		if err == nil || !strings.Contains(err.Error(), "-r requires") {
+			t.Fatalf("input %q: error = %v", input, err)
+		}
 	}
 }

--- a/sbg/sbg.go
+++ b/sbg/sbg.go
@@ -63,7 +63,7 @@ func (c *Converter) load(source string, reader io.Reader) (*synapseq.LoadedConte
 }
 
 func build(parsed *sequence) (*spsq.Builder, error) {
-	builder := spsq.New()
+	builder := spsq.New().SampleRate(parsed.sampleRate)
 	var musicName string
 	if parsed.musicPath != "" {
 		musicPath, err := currentRelativeMusicPath(parsed.musicPath)

--- a/sbg/sbg_test.go
+++ b/sbg/sbg_test.go
@@ -118,6 +118,39 @@ func TestLoadContentSupportsAbsoluteTimelineTimes(t *testing.T) {
 	}
 }
 
+func TestLoadContentConvertsSampleRate(t *testing.T) {
+	loaded, err := newTestConverter(t).LoadContent("-r 48000\nalpha: 300+10/20\nNOW alpha\n")
+	if err != nil {
+		t.Fatalf("LoadContent error: %v", err)
+	}
+	if loaded.SampleRate() != 48000 {
+		t.Fatalf("sample rate = %d", loaded.SampleRate())
+	}
+	if !strings.Contains(string(loaded.RawContent()), "@samplerate 48000") {
+		t.Fatalf("sample rate was not converted:\n%s", loaded.RawContent())
+	}
+}
+
+func TestLoadContentUsesDefaultSampleRate(t *testing.T) {
+	loaded, err := newTestConverter(t).LoadContent("alpha: 300+10/20\nNOW alpha\n")
+	if err != nil {
+		t.Fatalf("LoadContent error: %v", err)
+	}
+	if loaded.SampleRate() != defaultSampleRate {
+		t.Fatalf("sample rate = %d", loaded.SampleRate())
+	}
+	if !strings.Contains(string(loaded.RawContent()), "@samplerate 44100") {
+		t.Fatalf("default sample rate was not emitted:\n%s", loaded.RawContent())
+	}
+}
+
+func TestLoadContentDelegatesInvalidSampleRateToSPSQ(t *testing.T) {
+	_, err := newTestConverter(t).LoadContent("-r 0\nalpha: 300+10/20\nNOW alpha\n")
+	if err == nil || !strings.Contains(err.Error(), "invalid sample rate") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestLoadContentRejectsMixWithoutMusicSource(t *testing.T) {
 	_, err := newTestConverter(t).LoadContent("alpha: pink/20 mix/20\noff: -\nNOW alpha\n+00:01:00 off\n")
 	if err == nil || !strings.Contains(err.Error(), "mix voice requires a -m music source") {

--- a/sbg/types.go
+++ b/sbg/types.go
@@ -6,6 +6,8 @@ package sbg
 
 import "time"
 
+const defaultSampleRate = 44100
+
 type voiceKind int
 
 const (
@@ -40,6 +42,7 @@ type timelineEvent struct {
 
 type sequence struct {
 	source      string
+	sampleRate  int
 	musicPath   string
 	musicLine   int
 	definitions []nameDef


### PR DESCRIPTION
## Summary
- parse SBaGen -r sample rate options
- emit an explicit SPSQ sample rate, defaulting to 44100
- validate parsing errors and document conversion behavior

## Testing
- make test
- go vet ./sbg