### PR TITLE
feat: add AI sequence generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@
   &nbsp;&middot;&nbsp;
   <a href="#synapseq-remote">Remote</a>
   &nbsp;&middot;&nbsp;
-  <a href="#programmatic-api">Go API</a>
-  &nbsp;&middot;&nbsp;
-  <a href="#use-spsq-with-ai-agents">AI Agents</a>
+   <a href="#programmatic-api">Go API</a>
+   &nbsp;&middot;&nbsp;
+   <a href="#generate-spsq-with-ai">AI Generation</a>
+   &nbsp;&middot;&nbsp;
+   <a href="#use-spsq-with-ai-agents">AI Agents</a>
   &nbsp;&middot;&nbsp;
   <a href="docs/SYNTAX.md">Syntax</a>
 </p>
@@ -144,6 +146,35 @@ When the output is omitted, SynapSeq writes a `.spsq` file alongside the source 
 
 For a Go example using the `sbg` library, see [Programmatic API](#programmatic-api).
 
+## Generate SPSQ With AI
+
+Use `-ai` to generate a validated `.spsq` sequence from a natural-language prompt through an OpenAI-compatible API:
+
+```bash
+export SYNAPSEQ_AI_API_KEY="your-api-key"
+synapseq -ai "Generate a 10 minute relaxation sequence"
+```
+
+When no output path is given, SynapSeq creates a descriptive new `.spsq` file in the current directory. Supply a path to choose the destination, or `-` to write only SPSQ content to standard output:
+
+```bash
+synapseq -ai "Generate a 30 minute study sequence" study-30m.spsq
+synapseq -ai "Generate a 20 minute meditation sequence" -
+```
+
+SynapSeq requires `SYNAPSEQ_AI_API_KEY` and validates every model response before writing it. Invalid or unrecognized responses return an error and never create an output file. Existing destination files are not overwritten.
+
+Use an OpenAI-compatible local or remote model with environment variables:
+
+```bash
+export SYNAPSEQ_AI_API_KEY="local-key"
+export SYNAPSEQ_AI_MODEL="google/gemma-4-e4b"
+export SYNAPSEQ_AI_BASE_URL="http://localhost:1234"
+synapseq -ai "Generate a 15 minute focus sequence"
+```
+
+`SYNAPSEQ_AI_MODEL` and `SYNAPSEQ_AI_BASE_URL` are optional. The default model is `gpt-4.1-mini` and the default API host is OpenAI. Use `-ai-model MODEL` and `-ai-base-url URL` to override their environment-variable values for one command.
+
 ## Use SPSQ With AI Agents
 
 SynapSeq publishes three complementary [skills](https://skills.sh/synapseq-foundation/synapseq) for AI coding agents:
@@ -156,41 +187,15 @@ SynapSeq publishes three complementary [skills](https://skills.sh/synapseq-found
 
 Choose by the main action: **create**, **explain**, or **review**. The skills can hand work to one another through self-contained prompts, but only `create-spsq` writes complete sequence files, always at a new path.
 
-### Install the complete suite
+### Install
 
-Installing all three skills is recommended because they share routing and handoff conventions. The [`skills` CLI](https://github.com/vercel-labs/skills) accepts `'*'` to select every skill in the repository:
-
-```bash
-npx skills add synapseq-foundation/synapseq --skill '*'
-```
-
-The command is interactive and lets you choose the target agent and installation scope. For a global, non-interactive installation targeting one agent:
+Install all SynapSeq skills with the [`skills` CLI](https://github.com/vercel-labs/skills):
 
 ```bash
-# Codex
-npx skills add synapseq-foundation/synapseq --skill '*' --global --agent codex --yes
-
-# Claude Code
-npx skills add synapseq-foundation/synapseq --skill '*' --global --agent claude-code --yes
+npx skills add synapseq-foundation/synapseq
 ```
 
-Omit `--global` from these commands to install the suite only in the current project.
-
-To install all three skills for every supported agent detected by the CLI, without prompts:
-
-```bash
-npx skills add synapseq-foundation/synapseq --all
-```
-
-### Install one skill
-
-If you only need one responsibility, select it explicitly:
-
-```bash
-npx skills add synapseq-foundation/synapseq --skill create-spsq
-npx skills add synapseq-foundation/synapseq --skill explain-spsq
-npx skills add synapseq-foundation/synapseq --skill review-spsq
-```
+The command installs the complete skill suite and lets you choose the target agent and installation scope.
 
 ### Codex
 

--- a/cmd/synapseq/ai.go
+++ b/cmd/synapseq/ai.go
@@ -1,0 +1,149 @@
+// Copyright (C) 2026 SynapSeq Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	synapseq "github.com/synapseq-foundation/synapseq/v4/core"
+	"github.com/synapseq-foundation/synapseq/v4/internal/cli"
+)
+
+var promptDurationPattern = regexp.MustCompile(`(?i)\b(\d+)\s*(hours?|hrs?|h|minutes?|mins?|m)\b`)
+
+func runAI(prompt string, args []string, opts *cli.CLIOptions, statusWriter, outputWriter io.Writer) error {
+	if opts == nil {
+		return fmt.Errorf("CLI options are nil")
+	}
+	if strings.TrimSpace(prompt) == "" {
+		return fmt.Errorf("AI prompt cannot be empty")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("invalid AI generation arguments\nUsage: synapseq -ai <prompt> [output.spsq|-]")
+	}
+
+	outputPath := aiOutputPath(prompt)
+	if len(args) == 1 {
+		outputPath = args[0]
+	}
+	if outputPath != "-" && !strings.EqualFold(filepath.Ext(outputPath), ".spsq") {
+		return fmt.Errorf("SPSQ output must use the .spsq extension: %q", outputPath)
+	}
+	if outputPath != "-" {
+		if err := ensureAIOutputAvailable(outputPath); err != nil {
+			return err
+		}
+	}
+
+	progress := startAIProgress(statusWriter, opts.Quiet)
+
+	loaded, err := synapseq.NewAppContext().AI(prompt, &synapseq.AIOptions{
+		Model:   opts.AIModel,
+		BaseURL: opts.AIBaseURL,
+	})
+	progress.Stop()
+	if err != nil {
+		return err
+	}
+
+	content := loaded.RawContent()
+	if outputPath == "-" {
+		if outputWriter == nil {
+			return fmt.Errorf("SPSQ output writer is nil")
+		}
+		_, err := outputWriter.Write(content)
+		return err
+	}
+	if err := writeNewAISequence(outputPath, content); err != nil {
+		return err
+	}
+	if !opts.Quiet && statusWriter != nil {
+		_, err := fmt.Fprintln(statusWriter, cli.SuccessText("Generated:"), cli.Command(outputPath))
+		return err
+	}
+
+	return nil
+}
+
+func aiOutputPath(prompt string) string {
+	duration := promptDuration(prompt)
+	words := strings.FieldsFunc(strings.ToLower(prompt), func(r rune) bool {
+		return r < 'a' || r > 'z'
+	})
+
+	ignored := map[string]bool{
+		"a": true, "an": true, "and": true, "create": true, "generate": true,
+		"for": true, "hour": true, "hours": true, "minute": true, "minutes": true,
+		"of": true, "sequence": true, "the": true,
+	}
+	nameParts := []string{}
+	for _, word := range words {
+		if !ignored[word] {
+			nameParts = append(nameParts, word)
+		}
+	}
+	if len(nameParts) == 0 {
+		nameParts = append(nameParts, "generated")
+	}
+	if duration != "" {
+		nameParts = append(nameParts, duration)
+	}
+
+	name := strings.Join(nameParts, "-")
+	if len(name) > 48 {
+		name = name[:48]
+		name = strings.TrimRight(name, "-")
+	}
+
+	return name + ".spsq"
+}
+
+func promptDuration(prompt string) string {
+	matches := promptDurationPattern.FindStringSubmatch(prompt)
+	if len(matches) != 3 {
+		return ""
+	}
+
+	unit := strings.ToLower(matches[2])
+	if strings.HasPrefix(unit, "h") {
+		return matches[1] + "h"
+	}
+
+	return matches[1] + "m"
+}
+
+func writeNewAISequence(outputPath string, content []byte) error {
+	file, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("AI output already exists: %q", outputPath)
+		}
+		return fmt.Errorf("write generated sequence %q: %w", outputPath, err)
+	}
+	defer file.Close()
+
+	if _, err := file.Write(content); err != nil {
+		return fmt.Errorf("write generated sequence %q: %w", outputPath, err)
+	}
+
+	return nil
+}
+
+func ensureAIOutputAvailable(outputPath string) error {
+	_, err := os.Lstat(outputPath)
+	if err == nil {
+		return fmt.Errorf("AI output already exists: %q", outputPath)
+	}
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("check AI output %q: %w", outputPath, err)
+	}
+
+	return nil
+}

--- a/cmd/synapseq/ai_test.go
+++ b/cmd/synapseq/ai_test.go
@@ -1,0 +1,143 @@
+// Copyright (C) 2026 SynapSeq Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/synapseq-foundation/synapseq/v4/internal/cli"
+)
+
+func TestRunAIWritesValidatedSequence(ts *testing.T) {
+	server := aiTestServer(ts, `relax
+  tone 220 amplitude 10
+00:00:00 relax
+00:10:00 relax`)
+	defer server.Close()
+	ts.Setenv("SYNAPSEQ_AI_API_KEY", "test-key")
+
+	outputPath := filepath.Join(ts.TempDir(), "relax.spsq")
+	var status bytes.Buffer
+	err := runAI(
+		"Generate a 10 minutes of relaxation sequence",
+		[]string{outputPath},
+		&cli.CLIOptions{AIBaseURL: server.URL},
+		&status,
+		&bytes.Buffer{},
+	)
+	if err != nil {
+		ts.Fatalf("runAI error: %v", err)
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		ts.Fatalf("read output: %v", err)
+	}
+	if !strings.Contains(string(content), "tone 220") {
+		ts.Fatalf("unexpected output: %q", content)
+	}
+	if !strings.Contains(status.String(), "Generated:") {
+		ts.Fatalf("unexpected status: %q", status.String())
+	}
+	if !strings.Contains(status.String(), aiProgressMessage) {
+		ts.Fatalf("expected progress message, got %q", status.String())
+	}
+	generatedIndex := strings.Index(status.String(), "Generated:")
+	if generatedIndex < 0 || !strings.Contains(status.String()[:generatedIndex], "\n") {
+		ts.Fatalf("expected generated status on a new line, got %q", status.String())
+	}
+}
+
+func TestRunAIStreamsOnlySPSQ(ts *testing.T) {
+	server := aiTestServer(ts, `focus
+  noise pink smooth 20 amplitude 10
+00:00:00 focus
+00:05:00 focus`)
+	defer server.Close()
+	ts.Setenv("SYNAPSEQ_AI_API_KEY", "test-key")
+
+	var output bytes.Buffer
+	err := runAI("Generate focus", []string{"-"}, &cli.CLIOptions{AIBaseURL: server.URL}, &bytes.Buffer{}, &output)
+	if err != nil {
+		ts.Fatalf("runAI error: %v", err)
+	}
+	if strings.Contains(output.String(), "Generated:") || !strings.Contains(output.String(), "noise pink") {
+		ts.Fatalf("unexpected standard output: %q", output.String())
+	}
+}
+
+func TestRunAIRejectsExistingOutputBeforeRequest(ts *testing.T) {
+	outputPath := filepath.Join(ts.TempDir(), "existing.spsq")
+	if err := os.WriteFile(outputPath, []byte("existing"), 0o644); err != nil {
+		ts.Fatalf("create output: %v", err)
+	}
+
+	err := runAI("Generate focus", []string{outputPath}, &cli.CLIOptions{}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		ts.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunAIRejectsEmptyPrompt(ts *testing.T) {
+	err := runAI("", []string{"-"}, &cli.CLIOptions{}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "prompt cannot be empty") {
+		ts.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAIOutputPathUsesIntentAndDuration(ts *testing.T) {
+	if got := aiOutputPath("Generate a 10 minutes of relaxation sequence"); got != "relaxation-10m.spsq" {
+		ts.Fatalf("unexpected output path: %q", got)
+	}
+}
+
+func TestStartAIProgressDoesNotAnimateNonTerminal(ts *testing.T) {
+	var output bytes.Buffer
+	progress := startAIProgress(&output, false)
+	if progress != nil {
+		ts.Fatal("expected no spinner for a non-terminal writer")
+	}
+	if got := output.String(); !strings.Contains(got, aiProgressMessage) {
+		ts.Fatalf("expected progress message, got %q", got)
+	}
+}
+
+func TestStartAIProgressRespectsQuiet(ts *testing.T) {
+	var output bytes.Buffer
+	progress := startAIProgress(&output, true)
+	if progress != nil {
+		ts.Fatal("expected no spinner in quiet mode")
+	}
+	if got := output.String(); got != "" {
+		ts.Fatalf("expected no status output, got %q", got)
+	}
+}
+
+func TestAIProgressStopEndsLine(ts *testing.T) {
+	var output bytes.Buffer
+	progress := &aiProgress{
+		stop: make(chan struct{}),
+		done: make(chan struct{}),
+	}
+	go progress.animate(&output)
+	progress.Stop()
+
+	if !strings.HasSuffix(output.String(), "\n") {
+		ts.Fatalf("expected progress output to end with a newline, got %q", output.String())
+	}
+}
+
+func aiTestServer(ts *testing.T, content string) *httptest.Server {
+	ts.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write([]byte(`{"choices":[{"message":{"content":` + strconv.Quote(content) + `}}]}`))
+	}))
+}

--- a/cmd/synapseq/aiprogress.go
+++ b/cmd/synapseq/aiprogress.go
@@ -1,0 +1,84 @@
+// Copyright (C) 2026 SynapSeq Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/synapseq-foundation/synapseq/v4/internal/cli"
+)
+
+const aiProgressMessage = "Generating SPSQ sequence with AI. Please wait..."
+
+type aiProgress struct {
+	stop chan struct{}
+	done chan struct{}
+}
+
+func startAIProgress(writer io.Writer, quiet bool) *aiProgress {
+	if quiet || writer == nil {
+		return nil
+	}
+	if !canAnimateAIProgress(writer) {
+		_, _ = fmt.Fprintln(writer, cli.Muted(aiProgressMessage))
+		return nil
+	}
+
+	progress := &aiProgress{
+		stop: make(chan struct{}),
+		done: make(chan struct{}),
+	}
+	go progress.animate(writer)
+
+	return progress
+}
+
+func (p *aiProgress) Stop() {
+	if p == nil {
+		return
+	}
+
+	close(p.stop)
+	<-p.done
+}
+
+func (p *aiProgress) animate(writer io.Writer) {
+	defer close(p.done)
+
+	frames := []string{"|", "/", "-", `\`}
+	writeFrame := func(index int) {
+		_, _ = fmt.Fprintf(writer, "\r%s %s", cli.Accent(frames[index]), cli.Muted(aiProgressMessage))
+	}
+	writeFrame(0)
+
+	ticker := time.NewTicker(120 * time.Millisecond)
+	defer ticker.Stop()
+
+	for index := 1; ; index = (index + 1) % len(frames) {
+		select {
+		case <-p.stop:
+			_, _ = fmt.Fprintln(writer)
+			return
+		case <-ticker.C:
+			writeFrame(index)
+		}
+	}
+}
+
+func canAnimateAIProgress(writer io.Writer) bool {
+	file, ok := writer.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return false
+	}
+
+	return info.Mode()&os.ModeCharDevice != 0
+}

--- a/cmd/synapseq/dispatch.go
+++ b/cmd/synapseq/dispatch.go
@@ -52,6 +52,8 @@ func dispatchSpecialCommand(opts *cli.CLIOptions, args []string) (bool, error) {
 		return true, runDoctor()
 	case cli.SpecialCommandSBG:
 		return true, runSBGConversion(args, opts, os.Stderr, os.Stdout)
+	case cli.SpecialCommandAI:
+		return true, runAI(opts.AI, args, opts, os.Stderr, os.Stdout)
 	default:
 		return false, nil
 	}

--- a/core/ai.go
+++ b/core/ai.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 SynapSeq Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	internalai "github.com/synapseq-foundation/synapseq/v4/internal/ai"
+)
+
+const defaultAIModel = "gpt-4.1-mini"
+
+// AI generates and validates an SPSQ sequence from prompt using an
+// OpenAI-compatible chat completion API. The API key is read from
+// SYNAPSEQ_AI_API_KEY.
+func (ac *AppContext) AI(prompt string, options *AIOptions) (*LoadedContext, error) {
+	if ac == nil {
+		return nil, fmt.Errorf("app context is nil")
+	}
+
+	client, err := internalai.New(internalai.Config{
+		APIKey:  os.Getenv("SYNAPSEQ_AI_API_KEY"),
+		BaseURL: aiBaseURL(options),
+		Model:   aiModel(options),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := client.Generate(context.Background(), prompt)
+	if err != nil {
+		return nil, err
+	}
+
+	loaded, err := ac.LoadContent(content)
+	if err != nil {
+		return nil, fmt.Errorf("AI did not understand the prompt: generated content is not valid SPSQ: %w", err)
+	}
+
+	return loaded, nil
+}
+
+func aiModel(options *AIOptions) string {
+	if options != nil && strings.TrimSpace(options.Model) != "" {
+		return options.Model
+	}
+	if model := strings.TrimSpace(os.Getenv("SYNAPSEQ_AI_MODEL")); model != "" {
+		return model
+	}
+
+	return defaultAIModel
+}
+
+func aiBaseURL(options *AIOptions) string {
+	if options != nil && strings.TrimSpace(options.BaseURL) != "" {
+		return options.BaseURL
+	}
+
+	return os.Getenv("SYNAPSEQ_AI_BASE_URL")
+}

--- a/core/ai_test.go
+++ b/core/ai_test.go
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 SynapSeq Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package core
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAIValidatesGeneratedSPSQ(ts *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write([]byte(`{"choices":[{"message":{"content":"relax\n  tone 220 amplitude 10\n00:00:00 relax\n00:10:00 relax"}}]}`))
+	}))
+	defer server.Close()
+	ts.Setenv("SYNAPSEQ_AI_API_KEY", "test-key")
+
+	loaded, err := NewAppContext().AI("make relaxation", &AIOptions{BaseURL: server.URL})
+	if err != nil {
+		ts.Fatalf("AI error: %v", err)
+	}
+	if got := string(loaded.RawContent()); !strings.Contains(got, "relax") {
+		ts.Fatalf("unexpected content: %q", got)
+	}
+}
+
+func TestAIRejectsInvalidSPSQ(ts *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write([]byte(`{"choices":[{"message":{"content":"this is not spsq"}}]}`))
+	}))
+	defer server.Close()
+	ts.Setenv("SYNAPSEQ_AI_API_KEY", "test-key")
+
+	_, err := NewAppContext().AI("make relaxation", &AIOptions{BaseURL: server.URL})
+	if err == nil || !strings.Contains(err.Error(), "AI did not understand the prompt") {
+		ts.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAIOptionsOverrideEnvironment(ts *testing.T) {
+	ts.Setenv("SYNAPSEQ_AI_MODEL", "environment-model")
+	ts.Setenv("SYNAPSEQ_AI_BASE_URL", "https://environment.invalid")
+
+	options := &AIOptions{Model: "flag-model", BaseURL: "https://flag.invalid"}
+	if got := aiModel(options); got != "flag-model" {
+		ts.Fatalf("expected flag model, got %q", got)
+	}
+	if got := aiBaseURL(options); got != "https://flag.invalid" {
+		ts.Fatalf("expected flag base URL, got %q", got)
+	}
+}

--- a/core/types.go
+++ b/core/types.go
@@ -18,6 +18,14 @@ type AppContext struct {
 	statusColors bool
 }
 
+// AIOptions configures an OpenAI-compatible model used to generate SPSQ text.
+// Empty Model and BaseURL values use SYNAPSEQ_AI_MODEL and SYNAPSEQ_AI_BASE_URL,
+// then SynapSeq defaults.
+type AIOptions struct {
+	Model   string
+	BaseURL string
+}
+
 // LoadedContext holds a loaded sequence and execution settings.
 type LoadedContext struct {
 	appCtx   *AppContext

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -1,0 +1,157 @@
+// Copyright (C) 2026 SynapSeq Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package ai communicates with OpenAI-compatible chat completion APIs.
+package ai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const defaultBaseURL = "https://api.openai.com/v1"
+
+type Config struct {
+	APIKey  string
+	BaseURL string
+	Model   string
+}
+
+type Client struct {
+	config     Config
+	httpClient *http.Client
+}
+
+type chatCompletionRequest struct {
+	Model       string    `json:"model"`
+	Messages    []message `json:"messages"`
+	Temperature float64   `json:"temperature"`
+}
+
+type message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatCompletionResponse struct {
+	Choices []choice `json:"choices"`
+}
+
+type choice struct {
+	Message message `json:"message"`
+}
+
+type apiErrorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+func New(config Config) (*Client, error) {
+	if strings.TrimSpace(config.APIKey) == "" {
+		return nil, fmt.Errorf("SYNAPSEQ_AI_API_KEY is not set")
+	}
+	if strings.TrimSpace(config.Model) == "" {
+		return nil, fmt.Errorf("AI model cannot be empty")
+	}
+
+	baseURL, err := completionURL(config.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+	config.BaseURL = baseURL
+
+	return &Client{
+		config:     config,
+		httpClient: http.DefaultClient,
+	}, nil
+}
+
+func (c *Client) Generate(ctx context.Context, prompt string) (string, error) {
+	if strings.TrimSpace(prompt) == "" {
+		return "", fmt.Errorf("AI prompt cannot be empty")
+	}
+
+	body, err := json.Marshal(chatCompletionRequest{
+		Model: c.config.Model,
+		Messages: []message{
+			{Role: "system", Content: systemPrompt},
+			{Role: "user", Content: prompt},
+		},
+		Temperature: 0.2,
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode AI request: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		c.config.BaseURL,
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		return "", fmt.Errorf("create AI request: %w", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+c.config.APIKey)
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("request AI completion: %w", err)
+	}
+	defer response.Body.Close()
+
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return "", fmt.Errorf("read AI response: %w", err)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return "", apiError(response.StatusCode, responseBody)
+	}
+
+	var completion chatCompletionResponse
+	if err := json.Unmarshal(responseBody, &completion); err != nil {
+		return "", fmt.Errorf("decode AI response: %w", err)
+	}
+	if len(completion.Choices) == 0 || strings.TrimSpace(completion.Choices[0].Message.Content) == "" {
+		return "", fmt.Errorf("AI did not understand the prompt")
+	}
+
+	return strings.TrimSpace(completion.Choices[0].Message.Content) + "\n", nil
+}
+
+func completionURL(baseURL string) (string, error) {
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("invalid AI base URL %q", baseURL)
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	if !strings.HasSuffix(parsed.Path, "/v1") {
+		parsed.Path += "/v1"
+	}
+	parsed.Path += "/chat/completions"
+
+	return parsed.String(), nil
+}
+
+func apiError(statusCode int, body []byte) error {
+	var response apiErrorResponse
+	if err := json.Unmarshal(body, &response); err == nil && response.Error.Message != "" {
+		return fmt.Errorf("AI API returned HTTP %d: %s", statusCode, response.Error.Message)
+	}
+
+	return fmt.Errorf("AI API returned HTTP %d", statusCode)
+}

--- a/internal/ai/client_test.go
+++ b/internal/ai/client_test.go
@@ -1,0 +1,80 @@
+// Copyright (C) 2026 SynapSeq Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGenerateSendsOpenAICompatibleRequest(ts *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost {
+			ts.Errorf("expected POST, got %s", request.Method)
+		}
+		if request.URL.Path != "/v1/chat/completions" {
+			ts.Errorf("unexpected path: %s", request.URL.Path)
+		}
+		if got := request.Header.Get("Authorization"); got != "Bearer test-key" {
+			ts.Errorf("unexpected authorization: %q", got)
+		}
+
+		var body chatCompletionRequest
+		if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+			ts.Errorf("decode request: %v", err)
+		}
+		if body.Model != "local-model" || len(body.Messages) != 2 {
+			ts.Errorf("unexpected request: %#v", body)
+		}
+		if body.Messages[1].Content != "make a sequence" {
+			ts.Errorf("unexpected user prompt: %q", body.Messages[1].Content)
+		}
+
+		_, _ = writer.Write([]byte(`{"choices":[{"message":{"content":"focus\n  tone 220 amplitude 10\n00:00:00 focus\n00:01:00 focus"}}]}`))
+	}))
+	defer server.Close()
+
+	client, err := New(Config{APIKey: "test-key", BaseURL: server.URL, Model: "local-model"})
+	if err != nil {
+		ts.Fatalf("New error: %v", err)
+	}
+
+	content, err := client.Generate(context.Background(), "make a sequence")
+	if err != nil {
+		ts.Fatalf("Generate error: %v", err)
+	}
+	if !strings.HasSuffix(content, "\n") || !strings.Contains(content, "tone 220") {
+		ts.Fatalf("unexpected content: %q", content)
+	}
+}
+
+func TestGenerateReportsAPIError(ts *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusUnauthorized)
+		_, _ = writer.Write([]byte(`{"error":{"message":"invalid key"}}`))
+	}))
+	defer server.Close()
+
+	client, err := New(Config{APIKey: "test-key", BaseURL: server.URL, Model: "local-model"})
+	if err != nil {
+		ts.Fatalf("New error: %v", err)
+	}
+
+	_, err = client.Generate(context.Background(), "make a sequence")
+	if err == nil || !strings.Contains(err.Error(), "HTTP 401: invalid key") {
+		ts.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewRequiresAPIKey(ts *testing.T) {
+	_, err := New(Config{Model: "test"})
+	if err == nil || !strings.Contains(err.Error(), "SYNAPSEQ_AI_API_KEY") {
+		ts.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/ai/prompt.go
+++ b/internal/ai/prompt.go
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 SynapSeq Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ai
+
+const systemPrompt = `You generate SynapSeq SPSQ audio sequences from user requests.
+Return only valid SPSQ source text. Do not use Markdown fences, prose, filenames, JSON, or explanations.
+If the request cannot be understood or cannot be represented safely as an SPSQ sequence, return an empty response.
+
+SPSQ is line-oriented, whitespace-tokenized, and has no quoted strings. Put options first, then named presets with tracks indented by exactly two ASCII spaces, then timeline entries. A track can NEVER be top-level: it must follow a preset name and begin with exactly two spaces. Names start with ASCII letters, use only letters, digits, underscores, or hyphens, have at most 20 characters, and cannot be silence. Do not invent ambiance or music assets; omit external layers unless their source is supplied.
+
+Useful options are @samplerate positive-integer and @volume 0-to-100. A direct preset needs at least one track. Use tones exactly as "tone 220 amplitude 15", "tone 220 binaural 8 amplitude 15", "tone 220 monaural 8 amplitude 15", or "tone 220 isochronic 8 amplitude 15". The number after binaural, monaural, or isochronic is mandatory and comes immediately after that keyword: never emit "tone 220 binaural amplitude 15". A non-default waveform must precede tone, for example "waveform triangle tone 220 amplitude 15"; never write a waveform after the carrier. Use noise exactly as "noise white amplitude 8", "noise pink smooth 20 amplitude 10", or "noise brown smooth 30 amplitude 10". Amplitude, smoothness, and effect intensity range from 0 to 100. Keep amplitudes conservative.
+
+Choose sources intentionally rather than producing a generic tone plus arbitrary noise. For focus, use a binaural tone by default when the user did not rule out headphones; a binaural beat needs headphones. If the user says they cannot use headphones, choose monaural or isochronic instead. Monaural gives an audible amplitude beat; isochronic gives a more distinct pulse. For relaxation or meditation, use a gentler binaural, monaural, or simple tone according to the request. White noise is brighter, pink noise is balanced, and brown noise is lower and warmer; select a color that fits the requested character instead of always choosing brown. Unless the user requests minimalism or specifies exact sources, make each playable preset a restrained, complementary layer: one beat or tone track and one noise track. Do not invent ambiance or music resources.
+
+Treat sleep, study, lucid-dream, astral-projection, meditation, relaxation, focus, and energy requests as creative listening goals, not guaranteed cognitive, medical, therapeutic, sleep, or spiritual outcomes. Build a coherent trajectory for the stated goal instead of choosing random frequencies. Use the following beat-rate ranges as sound-design references when a beat is appropriate: delta 1-4 Hz for sleep-oriented descent; theta 4-8 Hz for meditation, dream exploration, lucid-dream, or astral-projection-themed sessions; alpha 8-12 Hz for relaxed awareness; low beta 13-18 Hz for focused study; and beta 18-24 Hz for an alert, energetic character. These ranges are creative parameters, not claims about what the listener will experience.
+
+For sessions longer than ten minutes, you MUST create at least two active presets unless the user explicitly asks for a static or minimal sequence. Keep compatible track purposes in the same declaration order in every active preset. The final timeline timestamp MUST exactly match the requested duration and MUST be one final silence entry. Repeat the final active preset 15 to 30 seconds before that timestamp to start the fade; do not place silence earlier.
+
+For sleep, begin with a relaxed alpha or theta character and gradually lower the beat toward theta or delta, using pink or brown noise. For study or focus, enter through alpha and settle into low beta, using a restrained binaural beat by default or monaural/isochronic without headphones; pink or white noise can provide a light background. For meditation, begin around alpha and settle into theta with a calm tone and pink or brown noise. For lucid-dream or astral-projection-themed sessions, use a gentle alpha-to-theta descent and avoid promising an experience. For an energy or mood-lifting character, rise from alpha or low beta toward beta, with a brighter tone or white/pink noise while retaining conservative amplitude. Use smooth transitions between phases and reserve the final short interval for the fade to silence.
+
+For example, this is the required phase structure for a 30-minute sleep-oriented session; adapt its sources and beat values for other requests, but retain the same structural logic:
+sleep-entry
+  tone 180 binaural 8 amplitude 12
+  noise brown smooth 25 amplitude 10
+
+sleep-deep
+  tone 180 binaural 3 amplitude 10
+  noise brown smooth 35 amplitude 12
+
+00:00:00 silence smooth
+00:00:20 sleep-entry smooth
+00:10:00 sleep-deep smooth
+00:29:40 sleep-deep smooth
+00:30:00 silence
+
+Timeline entries are "HH:MM:SS PRESET [steady|ease-in|ease-out|smooth [STEPS]]". The first entry must be 00:00:00, timestamps must strictly increase, and every sequence needs at least two entries. HH is hours, MM is minutes, and SS is seconds: five minutes is 00:05:00, not 05:00:00. Built-in silence is valid only as a first and/or final entry, never consecutively or in the middle. For a fade-in use "00:00:00 silence smooth" followed by an active preset. For a fade-out, repeat the active preset at fade start, then finish with one silence entry. Never transition directly from the first active preset to final silence over most of a session. Instead, for a 20-minute session, use an active preset around 00:19:40 followed by final silence at 00:20:00. The transition belongs to the entry that starts an interval. Steps are optional, capped at 12, and each trajectory leg needs at least five seconds. Create a modest entrance, active phase or phases, and exit matching the requested duration. Do not make medical, therapeutic, cognitive, or sleep claims.
+
+Use this valid five-minute relaxation sequence as the minimum structural model. Adapt its names, tracks, phases, and timestamps to the request, but preserve its ordering and indentation rules:
+@volume 70
+
+relax
+  tone 220 amplitude 12
+  noise pink smooth 20 amplitude 8
+
+00:00:00 silence smooth
+00:00:20 relax smooth
+00:04:40 relax smooth
+00:05:00 silence
+
+When the request specifies phase durations, preserve the stated phase order and calculate cumulative timestamps before writing the timeline. The clause before "after" always comes first; do not reverse it. Every timestamp must be unique and strictly increasing. For example, phases of 7, 5, and 12 minutes total 24 minutes: start the second phase at 00:07:00, the third at 00:12:00, repeat the third preset at 00:23:40 to begin its final fade, and use exactly one final "00:24:00 silence" entry. A request for relaxation for 7 minutes, alertness for 5 minutes, then alpha for 12 minutes must therefore use relaxation first, alertness at 00:07:00, and alpha at 00:12:00. Start a fading sequence with only one silence entry at 00:00:00, followed by relaxation at 00:00:20; never place an active preset and silence at the same timestamp.
+
+Before replying, verify that every track is under a preset, every active timeline preset exists, silence occurs only at timeline boundaries, phase order and cumulative durations match the request, no timestamps overlap, and the final timestamp matches the requested duration.`

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -24,6 +24,7 @@ const (
 	SpecialCommandUninstallFileAssociation SpecialCommandKind = "uninstall-file-association"
 	SpecialCommandDoctor                   SpecialCommandKind = "doctor"
 	SpecialCommandSBG                      SpecialCommandKind = "sbg"
+	SpecialCommandAI                       SpecialCommandKind = "ai"
 )
 
 type SpecialCommand struct {
@@ -83,6 +84,14 @@ type CLIOptions struct {
 	CompletionZsh bool
 	// Print completion args (param:desc format)
 	CompletionArgs bool
+	// Generate an SPSQ sequence with an AI prompt
+	AI string
+	// Whether the -ai flag was provided, including with an empty prompt
+	AIRequested bool
+	// OpenAI-compatible model name for AI generation
+	AIModel string
+	// OpenAI-compatible API host for AI generation
+	AIBaseURL string
 }
 
 func init() {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -295,6 +295,49 @@ func TestParseFlags(ts *testing.T) {
 	}
 }
 
+func TestParseFlagsAI(ts *testing.T) {
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	os.Args = []string{
+		"cmd",
+		"-ai", "generate relaxation",
+		"-ai-model", "local-model",
+		"-ai-base-url", "http://localhost:1234",
+		"output.spsq",
+	}
+	opts, args, err := ParseFlags()
+	if err != nil {
+		ts.Fatalf("ParseFlags error: %v", err)
+	}
+	if opts.AI != "generate relaxation" || opts.AIModel != "local-model" || opts.AIBaseURL != "http://localhost:1234" {
+		ts.Fatalf("unexpected AI options: %#v", opts)
+	}
+	if len(args) != 1 || args[0] != "output.spsq" {
+		ts.Fatalf("unexpected positional arguments: %#v", args)
+	}
+	if command := ResolveSpecialCommand(opts, args); command.Kind != SpecialCommandAI {
+		ts.Fatalf("expected AI special command, got %q", command.Kind)
+	}
+}
+
+func TestParseFlagsEmptyAIPromptIsSpecialCommand(ts *testing.T) {
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	os.Args = []string{"cmd", "-ai", "", "-"}
+	opts, args, err := ParseFlags()
+	if err != nil {
+		ts.Fatalf("ParseFlags error: %v", err)
+	}
+	if !opts.AIRequested {
+		ts.Fatal("expected -ai to be recorded")
+	}
+	if command := ResolveSpecialCommand(opts, args); command.Kind != SpecialCommandAI {
+		ts.Fatalf("expected AI special command, got %q", command.Kind)
+	}
+}
+
 func TestParseFlagsEdgeCases(ts *testing.T) {
 	originalArgs := os.Args
 	defer func() { os.Args = originalArgs }()

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -47,6 +47,11 @@ func ParseFlags() (*CLIOptions, []string, error) {
 	if err != nil {
 		return nil, nil, formatFlagParseError(fs, err)
 	}
+	fs.Visit(func(current *flag.Flag) {
+		if current.Name == "ai" {
+			opts.AIRequested = true
+		}
+	})
 
 	SetColorEnabled(!opts.NoColor)
 
@@ -78,7 +83,8 @@ func ResolveSpecialCommand(opts *CLIOptions, args []string) SpecialCommand {
 				return SpecialCommand{Kind: binding.SpecialCommand, OptionalArg: optionalArg}
 			}
 		case flagValueString:
-			if *binding.BindString(opts) != "" {
+			isEmptyAIPrompt := binding.Name == "ai" && opts.AIRequested
+			if *binding.BindString(opts) != "" || isEmptyAIPrompt {
 				return SpecialCommand{Kind: binding.SpecialCommand, OptionalArg: optionalArg}
 			}
 		}
@@ -134,6 +140,9 @@ func flagBindings() []flagBinding {
 	return []flagBinding{
 		{Name: "version", Usage: "Show version information", ValueKind: flagValueBool, BindBool: func(opts *CLIOptions) *bool { return &opts.ShowVersion }, SpecialCommand: SpecialCommandShowVersion},
 		{Name: "sbg", Usage: "Convert an SBaGen file to SPSQ", ValueKind: flagValueBool, BindBool: func(opts *CLIOptions) *bool { return &opts.ConvertSBG }, SpecialCommand: SpecialCommandSBG},
+		{Name: "ai", Usage: "Generate an SPSQ sequence from a prompt", ValueKind: flagValueString, BindString: func(opts *CLIOptions) *string { return &opts.AI }, SpecialCommand: SpecialCommandAI},
+		{Name: "ai-model", Usage: "OpenAI-compatible model for -ai", ValueKind: flagValueString, BindString: func(opts *CLIOptions) *string { return &opts.AIModel }},
+		{Name: "ai-base-url", Usage: "OpenAI-compatible API host for -ai", ValueKind: flagValueString, BindString: func(opts *CLIOptions) *string { return &opts.AIBaseURL }},
 		{Name: "dump", Usage: "Render JSON sequence data", ValueKind: flagValueBool, BindBool: func(opts *CLIOptions) *bool { return &opts.Dump }},
 		{Name: "quiet", Usage: "Enable quiet mode", ValueKind: flagValueBool, BindBool: func(opts *CLIOptions) *bool { return &opts.Quiet }},
 		{Name: "no-color", Usage: "Disable ANSI colors in CLI output", ValueKind: flagValueBool, BindBool: func(opts *CLIOptions) *bool { return &opts.NoColor }},

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -34,6 +34,9 @@ func Help() {
 	writeInputSection(writer)
 	writeOutputSection(writer)
 	writeOptionsSection(writer, "Most common options:", commonHelpOptions())
+	writeMutedLeadSection(writer, "AI:", "Requires SYNAPSEQ_AI_API_KEY. Model and API host can also be configured with environment variables.")
+	writeOptionsList(writer, aiHelpOptions())
+	fmt.Fprintln(writer)
 	writeMutedLeadSection(writer, "Remote:", "Run -sync first to initialize the local Remote index.")
 	writeOptionsList(writer, remoteHelpOptions())
 	fmt.Fprintln(writer)
@@ -123,6 +126,7 @@ func quickStartExamples() []helpExample {
 		{Label: "2. Play audio", CommandText: "synapseq -play session.spsq", Description: "Play the sequence directly with ffplay"},
 		{Label: "3. Export to MP3", CommandText: "synapseq session.spsq session.mp3", Description: "Export to MP3 with ffmpeg"},
 		{Label: "4. Convert SBaGen", CommandText: "synapseq -sbg session.sbg [session.spsq]", Description: "Convert an SBaGen sequence to SPSQ"},
+		{Label: "5. Generate SPSQ", CommandText: "synapseq -ai \"10 minutes of relaxation\" [session.spsq]", Description: "Generate an SPSQ sequence with an OpenAI-compatible model"},
 	}
 }
 
@@ -140,6 +144,17 @@ func commonHelpOptions() []helpOption {
 		{FlagText: "-completion-bash", ColumnWidth: 19, Description: "Generate bash completion script"},
 		{FlagText: "-completion-zsh", ColumnWidth: 19, Description: "Generate zsh completion script"},
 		{FlagText: "-help", ColumnWidth: 19, Description: "Show this help message"},
+	}
+}
+
+func aiHelpOptions() []helpOption {
+	return []helpOption{
+		{FlagText: "-ai PROMPT [OUTPUT]", ColumnWidth: 28, Description: "Generate an SPSQ sequence; use - for standard output"},
+		{FlagText: "-ai-model MODEL", ColumnWidth: 28, Description: "Overrides SYNAPSEQ_AI_MODEL"},
+		{FlagText: "-ai-base-url URL", ColumnWidth: 28, Description: "Overrides SYNAPSEQ_AI_BASE_URL"},
+		{FlagText: "SYNAPSEQ_AI_API_KEY", ColumnWidth: 28, Description: "Required API key"},
+		{FlagText: "SYNAPSEQ_AI_MODEL", ColumnWidth: 28, Description: "Model name; defaults to gpt-4.1-mini"},
+		{FlagText: "SYNAPSEQ_AI_BASE_URL", ColumnWidth: 28, Description: "OpenAI-compatible API host"},
 	}
 }
 


### PR DESCRIPTION
## Summary
- add OpenAI-compatible SPSQ generation through the -ai command
- validate every model response before output and support local model configuration
- add terminal progress feedback, CLI help, tests, and README documentation

## Testing
- make test