### PR TITLE
feat: configure AI temperature

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,11 @@ Use an OpenAI-compatible local or remote model with environment variables:
 export SYNAPSEQ_AI_API_KEY="local-key"
 export SYNAPSEQ_AI_MODEL="google/gemma-4-e4b"
 export SYNAPSEQ_AI_BASE_URL="http://localhost:1234"
+export SYNAPSEQ_AI_TEMPERATURE="0.2"
 synapseq -ai "Generate a 15 minute focus sequence"
 ```
 
-`SYNAPSEQ_AI_MODEL` and `SYNAPSEQ_AI_BASE_URL` are optional. The default model is `gpt-4.1-mini` and the default API host is OpenAI. Use `-ai-model MODEL` and `-ai-base-url URL` to override their environment-variable values for one command.
+`SYNAPSEQ_AI_MODEL`, `SYNAPSEQ_AI_BASE_URL`, and `SYNAPSEQ_AI_TEMPERATURE` are optional. The default model is `gpt-4.1-mini` and the default API host is OpenAI. When temperature is omitted, SynapSeq lets the selected model use its default; this is required by models that do not accept a custom temperature. Use `-ai-model MODEL`, `-ai-base-url URL`, and `-ai-temperature VALUE` to override their environment-variable values for one command.
 
 To generate SPSQ through the public Go API, see [AI Generation From Go](#ai-generation-from-go).
 

--- a/cmd/synapseq/ai.go
+++ b/cmd/synapseq/ai.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	synapseq "github.com/synapseq-foundation/synapseq/v4/core"
@@ -42,11 +43,17 @@ func runAI(prompt string, args []string, opts *cli.CLIOptions, statusWriter, out
 		}
 	}
 
+	temperature, err := cliAITemperature(opts.AITemperature)
+	if err != nil {
+		return err
+	}
+
 	progress := startAIProgress(statusWriter, opts.Quiet)
 
 	loaded, err := synapseq.NewAppContext().AI(prompt, &synapseq.AIOptions{
-		Model:   opts.AIModel,
-		BaseURL: opts.AIBaseURL,
+		Model:       opts.AIModel,
+		BaseURL:     opts.AIBaseURL,
+		Temperature: temperature,
 	})
 	progress.Stop()
 	if err != nil {
@@ -70,6 +77,19 @@ func runAI(prompt string, args []string, opts *cli.CLIOptions, statusWriter, out
 	}
 
 	return nil
+}
+
+func cliAITemperature(value string) (*float64, error) {
+	if strings.TrimSpace(value) == "" {
+		return nil, nil
+	}
+
+	temperature, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid -ai-temperature %q: %w", value, err)
+	}
+
+	return &temperature, nil
 }
 
 func aiOutputPath(prompt string) string {

--- a/cmd/synapseq/ai_test.go
+++ b/cmd/synapseq/ai_test.go
@@ -99,6 +99,20 @@ func TestAIOutputPathUsesIntentAndDuration(ts *testing.T) {
 	}
 }
 
+func TestCLIAITemperature(ts *testing.T) {
+	temperature, err := cliAITemperature("0.2")
+	if err != nil {
+		ts.Fatalf("cliAITemperature error: %v", err)
+	}
+	if temperature == nil || *temperature != 0.2 {
+		ts.Fatalf("unexpected temperature: %#v", temperature)
+	}
+
+	if _, err := cliAITemperature("not-a-number"); err == nil {
+		ts.Fatal("expected invalid temperature error")
+	}
+}
+
 func TestStartAIProgressDoesNotAnimateNonTerminal(ts *testing.T) {
 	var output bytes.Buffer
 	progress := startAIProgress(&output, false)

--- a/core/ai.go
+++ b/core/ai.go
@@ -7,7 +7,9 @@ package core
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
+	"strconv"
 	"strings"
 
 	internalai "github.com/synapseq-foundation/synapseq/v4/internal/ai"
@@ -23,10 +25,16 @@ func (ac *AppContext) AI(prompt string, options *AIOptions) (*LoadedContext, err
 		return nil, fmt.Errorf("app context is nil")
 	}
 
+	temperature, err := aiTemperature(options)
+	if err != nil {
+		return nil, err
+	}
+
 	client, err := internalai.New(internalai.Config{
-		APIKey:  os.Getenv("SYNAPSEQ_AI_API_KEY"),
-		BaseURL: aiBaseURL(options),
-		Model:   aiModel(options),
+		APIKey:      os.Getenv("SYNAPSEQ_AI_API_KEY"),
+		BaseURL:     aiBaseURL(options),
+		Model:       aiModel(options),
+		Temperature: temperature,
 	})
 	if err != nil {
 		return nil, err
@@ -62,4 +70,30 @@ func aiBaseURL(options *AIOptions) string {
 	}
 
 	return os.Getenv("SYNAPSEQ_AI_BASE_URL")
+}
+
+func aiTemperature(options *AIOptions) (*float64, error) {
+	if options != nil && options.Temperature != nil {
+		return options.Temperature, validateAITemperature(*options.Temperature)
+	}
+
+	value := strings.TrimSpace(os.Getenv("SYNAPSEQ_AI_TEMPERATURE"))
+	if value == "" {
+		return nil, nil
+	}
+
+	temperature, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid SYNAPSEQ_AI_TEMPERATURE %q: %w", value, err)
+	}
+
+	return &temperature, validateAITemperature(temperature)
+}
+
+func validateAITemperature(temperature float64) error {
+	if math.IsNaN(temperature) || math.IsInf(temperature, 0) || temperature < 0 || temperature > 2 {
+		return fmt.Errorf("AI temperature must be between 0 and 2")
+	}
+
+	return nil
 }

--- a/core/ai_test.go
+++ b/core/ai_test.go
@@ -52,3 +52,36 @@ func TestAIOptionsOverrideEnvironment(ts *testing.T) {
 		ts.Fatalf("expected flag base URL, got %q", got)
 	}
 }
+
+func TestAITemperatureUsesOptionsBeforeEnvironment(ts *testing.T) {
+	ts.Setenv("SYNAPSEQ_AI_TEMPERATURE", "0.2")
+	temperature := 0.7
+
+	got, err := aiTemperature(&AIOptions{Temperature: &temperature})
+	if err != nil {
+		ts.Fatalf("aiTemperature error: %v", err)
+	}
+	if got == nil || *got != 0.7 {
+		ts.Fatalf("expected option temperature 0.7, got %#v", got)
+	}
+}
+
+func TestAITemperatureUsesEnvironment(ts *testing.T) {
+	ts.Setenv("SYNAPSEQ_AI_TEMPERATURE", "0.2")
+
+	got, err := aiTemperature(nil)
+	if err != nil {
+		ts.Fatalf("aiTemperature error: %v", err)
+	}
+	if got == nil || *got != 0.2 {
+		ts.Fatalf("expected environment temperature 0.2, got %#v", got)
+	}
+}
+
+func TestAITemperatureRejectsInvalidValue(ts *testing.T) {
+	ts.Setenv("SYNAPSEQ_AI_TEMPERATURE", "3")
+
+	if _, err := aiTemperature(nil); err == nil {
+		ts.Fatal("expected invalid temperature error")
+	}
+}

--- a/core/doc.go
+++ b/core/doc.go
@@ -90,7 +90,9 @@ Use AppContext.AI to generate and validate an SPSQ sequence with an
 OpenAI-compatible chat completion API. Set SYNAPSEQ_AI_API_KEY before calling
 AI. Model and API host default to gpt-4.1-mini and the OpenAI API; configure a
 local or alternate provider through AIOptions or the SYNAPSEQ_AI_MODEL and
-SYNAPSEQ_AI_BASE_URL environment variables.
+SYNAPSEQ_AI_BASE_URL environment variables. Set SYNAPSEQ_AI_TEMPERATURE to a
+value from 0 through 2 when the selected model supports custom sampling
+temperature; otherwise leave it unset to use the model default.
 
 	ctx := synapseq.NewAppContext()
 	loaded, err := ctx.AI("Generate a 10 minute relaxation sequence", &synapseq.AIOptions{

--- a/core/types.go
+++ b/core/types.go
@@ -20,10 +20,12 @@ type AppContext struct {
 
 // AIOptions configures an OpenAI-compatible model used to generate SPSQ text.
 // Empty Model and BaseURL values use SYNAPSEQ_AI_MODEL and SYNAPSEQ_AI_BASE_URL,
-// then SynapSeq defaults.
+// then SynapSeq defaults. A nil Temperature uses SYNAPSEQ_AI_TEMPERATURE or
+// omits temperature so the selected model can use its default.
 type AIOptions struct {
-	Model   string
-	BaseURL string
+	Model       string
+	BaseURL     string
+	Temperature *float64
 }
 
 // LoadedContext holds a loaded sequence and execution settings.

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -19,9 +19,10 @@ import (
 const defaultBaseURL = "https://api.openai.com/v1"
 
 type Config struct {
-	APIKey  string
-	BaseURL string
-	Model   string
+	APIKey      string
+	BaseURL     string
+	Model       string
+	Temperature *float64
 }
 
 type Client struct {
@@ -32,7 +33,7 @@ type Client struct {
 type chatCompletionRequest struct {
 	Model       string    `json:"model"`
 	Messages    []message `json:"messages"`
-	Temperature float64   `json:"temperature"`
+	Temperature *float64  `json:"temperature,omitempty"`
 }
 
 type message struct {
@@ -85,7 +86,7 @@ func (c *Client) Generate(ctx context.Context, prompt string) (string, error) {
 			{Role: "system", Content: systemPrompt},
 			{Role: "user", Content: prompt},
 		},
-		Temperature: 0.2,
+		Temperature: c.config.Temperature,
 	})
 	if err != nil {
 		return "", fmt.Errorf("encode AI request: %w", err)

--- a/internal/ai/client_test.go
+++ b/internal/ai/client_test.go
@@ -35,6 +35,9 @@ func TestGenerateSendsOpenAICompatibleRequest(ts *testing.T) {
 		if body.Messages[1].Content != "make a sequence" {
 			ts.Errorf("unexpected user prompt: %q", body.Messages[1].Content)
 		}
+		if body.Temperature != nil {
+			ts.Errorf("expected default temperature to be omitted, got %v", *body.Temperature)
+		}
 
 		_, _ = writer.Write([]byte(`{"choices":[{"message":{"content":"focus\n  tone 220 amplitude 10\n00:00:00 focus\n00:01:00 focus"}}]}`))
 	}))
@@ -51,6 +54,35 @@ func TestGenerateSendsOpenAICompatibleRequest(ts *testing.T) {
 	}
 	if !strings.HasSuffix(content, "\n") || !strings.Contains(content, "tone 220") {
 		ts.Fatalf("unexpected content: %q", content)
+	}
+}
+
+func TestGenerateSendsConfiguredTemperature(ts *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		var body chatCompletionRequest
+		if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+			ts.Errorf("decode request: %v", err)
+		}
+		if body.Temperature == nil || *body.Temperature != 0.7 {
+			ts.Errorf("unexpected temperature: %#v", body.Temperature)
+		}
+
+		_, _ = writer.Write([]byte(`{"choices":[{"message":{"content":"focus\n  tone 220 amplitude 10\n00:00:00 focus\n00:01:00 focus"}}]}`))
+	}))
+	defer server.Close()
+
+	temperature := 0.7
+	client, err := New(Config{
+		APIKey:      "test-key",
+		BaseURL:     server.URL,
+		Model:       "local-model",
+		Temperature: &temperature,
+	})
+	if err != nil {
+		ts.Fatalf("New error: %v", err)
+	}
+	if _, err := client.Generate(context.Background(), "make a sequence"); err != nil {
+		ts.Fatalf("Generate error: %v", err)
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -92,6 +92,8 @@ type CLIOptions struct {
 	AIModel string
 	// OpenAI-compatible API host for AI generation
 	AIBaseURL string
+	// Sampling temperature for AI generation
+	AITemperature string
 }
 
 func init() {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -304,13 +304,14 @@ func TestParseFlagsAI(ts *testing.T) {
 		"-ai", "generate relaxation",
 		"-ai-model", "local-model",
 		"-ai-base-url", "http://localhost:1234",
+		"-ai-temperature", "0.2",
 		"output.spsq",
 	}
 	opts, args, err := ParseFlags()
 	if err != nil {
 		ts.Fatalf("ParseFlags error: %v", err)
 	}
-	if opts.AI != "generate relaxation" || opts.AIModel != "local-model" || opts.AIBaseURL != "http://localhost:1234" {
+	if opts.AI != "generate relaxation" || opts.AIModel != "local-model" || opts.AIBaseURL != "http://localhost:1234" || opts.AITemperature != "0.2" {
 		ts.Fatalf("unexpected AI options: %#v", opts)
 	}
 	if len(args) != 1 || args[0] != "output.spsq" {

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -143,6 +143,7 @@ func flagBindings() []flagBinding {
 		{Name: "ai", Usage: "Generate an SPSQ sequence from a prompt", ValueKind: flagValueString, BindString: func(opts *CLIOptions) *string { return &opts.AI }, SpecialCommand: SpecialCommandAI},
 		{Name: "ai-model", Usage: "OpenAI-compatible model for -ai", ValueKind: flagValueString, BindString: func(opts *CLIOptions) *string { return &opts.AIModel }},
 		{Name: "ai-base-url", Usage: "OpenAI-compatible API host for -ai", ValueKind: flagValueString, BindString: func(opts *CLIOptions) *string { return &opts.AIBaseURL }},
+		{Name: "ai-temperature", Usage: "Sampling temperature for -ai", ValueKind: flagValueString, BindString: func(opts *CLIOptions) *string { return &opts.AITemperature }},
 		{Name: "dump", Usage: "Render JSON sequence data", ValueKind: flagValueBool, BindBool: func(opts *CLIOptions) *bool { return &opts.Dump }},
 		{Name: "quiet", Usage: "Enable quiet mode", ValueKind: flagValueBool, BindBool: func(opts *CLIOptions) *bool { return &opts.Quiet }},
 		{Name: "no-color", Usage: "Disable ANSI colors in CLI output", ValueKind: flagValueBool, BindBool: func(opts *CLIOptions) *bool { return &opts.NoColor }},

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -152,9 +152,11 @@ func aiHelpOptions() []helpOption {
 		{FlagText: "-ai PROMPT [OUTPUT]", ColumnWidth: 28, Description: "Generate an SPSQ sequence; use - for standard output"},
 		{FlagText: "-ai-model MODEL", ColumnWidth: 28, Description: "Overrides SYNAPSEQ_AI_MODEL"},
 		{FlagText: "-ai-base-url URL", ColumnWidth: 28, Description: "Overrides SYNAPSEQ_AI_BASE_URL"},
+		{FlagText: "-ai-temperature VALUE", ColumnWidth: 28, Description: "Overrides SYNAPSEQ_AI_TEMPERATURE"},
 		{FlagText: "SYNAPSEQ_AI_API_KEY", ColumnWidth: 28, Description: "Required API key"},
 		{FlagText: "SYNAPSEQ_AI_MODEL", ColumnWidth: 28, Description: "Model name; defaults to gpt-4.1-mini"},
 		{FlagText: "SYNAPSEQ_AI_BASE_URL", ColumnWidth: 28, Description: "OpenAI-compatible API host"},
+		{FlagText: "SYNAPSEQ_AI_TEMPERATURE", ColumnWidth: 28, Description: "Optional sampling temperature from 0 to 2"},
 	}
 }
 


### PR DESCRIPTION
## Summary
- add optional AI temperature configuration through CLI, environment, and core API
- omit temperature by default for models that require their default sampling value
- document the setting and add payload and precedence tests

## Testing
- make test