### PR TITLE
feat: add AI generation resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ export SYNAPSEQ_AI_API_KEY="local-key"
 export SYNAPSEQ_AI_MODEL="google/gemma-4-e4b"
 export SYNAPSEQ_AI_BASE_URL="http://localhost:1234"
 export SYNAPSEQ_AI_TEMPERATURE="0.2"
+export SYNAPSEQ_AI_TIMEOUT="90s"
 synapseq -ai "Generate a 15 minute focus sequence"
 ```
 
@@ -192,7 +193,9 @@ set SYNAPSEQ_AI_MODEL=gpt-4.1-mini
 synapseq -ai "Generate a 15 minute focus sequence"
 ```
 
-`SYNAPSEQ_AI_MODEL`, `SYNAPSEQ_AI_BASE_URL`, and `SYNAPSEQ_AI_TEMPERATURE` are optional. The default model is `gpt-4.1-mini` and the default API host is OpenAI. When temperature is omitted, SynapSeq lets the selected model use its default; this is required by models that do not accept a custom temperature. Use `-ai-model MODEL`, `-ai-base-url URL`, and `-ai-temperature VALUE` to override their environment-variable values for one command.
+`SYNAPSEQ_AI_MODEL`, `SYNAPSEQ_AI_BASE_URL`, `SYNAPSEQ_AI_TEMPERATURE`, and `SYNAPSEQ_AI_TIMEOUT` are optional. The default model is `gpt-4.1-mini`, the default API host is OpenAI, and requests time out after five minutes. When temperature is omitted, SynapSeq lets the selected model use its default; this is required by models that do not accept a custom temperature. Use `-ai-model MODEL`, `-ai-base-url URL`, `-ai-temperature VALUE`, and `-ai-timeout DURATION` to override their environment-variable values for one command.
+
+SynapSeq validates every response and automatically asks the model to repair invalid SPSQ up to two times. Press `Ctrl+C` to cancel a pending request.
 
 To generate SPSQ through the public Go API, see [AI Generation From Go](#ai-generation-from-go).
 
@@ -309,7 +312,7 @@ The public Go API can construct the same `.spsq` representation in code and pass
 
 ### AI Generation From Go
 
-`AppContext.AI` generates and validates SPSQ through an OpenAI-compatible API. Set `SYNAPSEQ_AI_API_KEY` before calling it; `AIOptions` can select a local model or API host:
+`AppContext.AI` generates and validates SPSQ through an OpenAI-compatible API. Set `SYNAPSEQ_AI_API_KEY` before calling it; `AIOptions` can select a local model, API host, or timeout:
 
 ```go
 package main
@@ -317,6 +320,7 @@ package main
 import (
 	"log"
 	"os"
+	"time"
 
 	synapseq "github.com/synapseq-foundation/synapseq/v4/core"
 )
@@ -326,6 +330,7 @@ func main() {
 	loaded, err := ctx.AI("Generate a 10 minute relaxation sequence", &synapseq.AIOptions{
 		Model:   "local-model",
 		BaseURL: "http://localhost:1234",
+		Timeout: durationPtr(90 * time.Second),
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -335,9 +340,13 @@ func main() {
 		log.Fatal(err)
 	}
 }
+
+func durationPtr(value time.Duration) *time.Duration {
+	return &value
+}
 ```
 
-Omit `AIOptions` to use `SYNAPSEQ_AI_MODEL`, `SYNAPSEQ_AI_BASE_URL`, and the default OpenAI configuration. The returned `LoadedContext` is already validated and can also be rendered directly with `loaded.WAV`.
+Omit `AIOptions` to use `SYNAPSEQ_AI_MODEL`, `SYNAPSEQ_AI_BASE_URL`, `SYNAPSEQ_AI_TIMEOUT`, and the default OpenAI configuration. Use `AppContext.AIContext` with your own `context.Context` when the calling program needs cancellation. The returned `LoadedContext` is already validated and can also be rendered directly with `loaded.WAV`.
 
 ### SPSQ Builder
 

--- a/cmd/synapseq/ai.go
+++ b/cmd/synapseq/ai.go
@@ -5,13 +5,16 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	synapseq "github.com/synapseq-foundation/synapseq/v4/core"
 	"github.com/synapseq-foundation/synapseq/v4/internal/cli"
@@ -20,6 +23,13 @@ import (
 var promptDurationPattern = regexp.MustCompile(`(?i)\b(\d+)\s*(hours?|hrs?|h|minutes?|mins?|m)\b`)
 
 func runAI(prompt string, args []string, opts *cli.CLIOptions, statusWriter, outputWriter io.Writer) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	return runAIContext(ctx, prompt, args, opts, statusWriter, outputWriter)
+}
+
+func runAIContext(ctx context.Context, prompt string, args []string, opts *cli.CLIOptions, statusWriter, outputWriter io.Writer) error {
 	if opts == nil {
 		return fmt.Errorf("CLI options are nil")
 	}
@@ -47,13 +57,18 @@ func runAI(prompt string, args []string, opts *cli.CLIOptions, statusWriter, out
 	if err != nil {
 		return err
 	}
+	timeout, err := cliAITimeout(opts.AITimeout)
+	if err != nil {
+		return err
+	}
 
 	progress := startAIProgress(statusWriter, opts.Quiet)
 
-	loaded, err := synapseq.NewAppContext().AI(prompt, &synapseq.AIOptions{
+	loaded, err := synapseq.NewAppContext().AIContext(ctx, prompt, &synapseq.AIOptions{
 		Model:       opts.AIModel,
 		BaseURL:     opts.AIBaseURL,
 		Temperature: temperature,
+		Timeout:     timeout,
 	})
 	progress.Stop()
 	if err != nil {
@@ -90,6 +105,22 @@ func cliAITemperature(value string) (*float64, error) {
 	}
 
 	return &temperature, nil
+}
+
+func cliAITimeout(value string) (*time.Duration, error) {
+	if strings.TrimSpace(value) == "" {
+		return nil, nil
+	}
+
+	timeout, err := time.ParseDuration(value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid -ai-timeout %q: %w", value, err)
+	}
+	if timeout <= 0 {
+		return nil, fmt.Errorf("AI timeout must be greater than zero")
+	}
+
+	return &timeout, nil
 }
 
 func aiOutputPath(prompt string) string {

--- a/cmd/synapseq/ai_test.go
+++ b/cmd/synapseq/ai_test.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/synapseq-foundation/synapseq/v4/internal/cli"
 )
@@ -110,6 +111,20 @@ func TestCLIAITemperature(ts *testing.T) {
 
 	if _, err := cliAITemperature("not-a-number"); err == nil {
 		ts.Fatal("expected invalid temperature error")
+	}
+}
+
+func TestCLIAITimeout(ts *testing.T) {
+	timeout, err := cliAITimeout("90s")
+	if err != nil {
+		ts.Fatalf("cliAITimeout error: %v", err)
+	}
+	if timeout == nil || *timeout != 90*time.Second {
+		ts.Fatalf("unexpected timeout: %#v", timeout)
+	}
+
+	if _, err := cliAITimeout("not-a-duration"); err == nil {
+		ts.Fatal("expected invalid timeout error")
 	}
 }
 

--- a/core/ai.go
+++ b/core/ai.go
@@ -6,29 +6,52 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	internalai "github.com/synapseq-foundation/synapseq/v4/internal/ai"
 )
 
-const defaultAIModel = "gpt-4.1-mini"
+const (
+	defaultAIModel   = "gpt-4.1-mini"
+	defaultAITimeout = 5 * time.Minute
+	aiRepairAttempts = 2
+)
 
 // AI generates and validates an SPSQ sequence from prompt using an
 // OpenAI-compatible chat completion API. The API key is read from
 // SYNAPSEQ_AI_API_KEY.
 func (ac *AppContext) AI(prompt string, options *AIOptions) (*LoadedContext, error) {
+	return ac.AIContext(context.Background(), prompt, options)
+}
+
+// AIContext generates and validates an SPSQ sequence from prompt using an
+// OpenAI-compatible chat completion API. The API key is read from
+// SYNAPSEQ_AI_API_KEY. The request stops when ctx is canceled or its configured
+// timeout expires.
+func (ac *AppContext) AIContext(ctx context.Context, prompt string, options *AIOptions) (*LoadedContext, error) {
 	if ac == nil {
 		return nil, fmt.Errorf("app context is nil")
+	}
+	if ctx == nil {
+		return nil, fmt.Errorf("AI context is nil")
 	}
 
 	temperature, err := aiTemperature(options)
 	if err != nil {
 		return nil, err
 	}
+	timeout, err := aiTimeout(options)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
 	client, err := internalai.New(internalai.Config{
 		APIKey:      os.Getenv("SYNAPSEQ_AI_API_KEY"),
@@ -40,17 +63,27 @@ func (ac *AppContext) AI(prompt string, options *AIOptions) (*LoadedContext, err
 		return nil, err
 	}
 
-	content, err := client.Generate(context.Background(), prompt)
+	content, err := client.Generate(ctx, prompt)
 	if err != nil {
-		return nil, err
+		return nil, aiContextError(ctx, timeout, err)
 	}
 
-	loaded, err := ac.LoadContent(content)
-	if err != nil {
-		return nil, fmt.Errorf("AI did not understand the prompt: generated content is not valid SPSQ: %w", err)
+	for attempt := 0; attempt <= aiRepairAttempts; attempt++ {
+		loaded, validationErr := ac.LoadContent(content)
+		if validationErr == nil {
+			return loaded, nil
+		}
+		if attempt == aiRepairAttempts {
+			return nil, fmt.Errorf("AI did not understand the prompt after %d repair attempts: generated content is not valid SPSQ: %w", aiRepairAttempts, validationErr)
+		}
+
+		content, err = client.Repair(ctx, prompt, content, validationErr)
+		if err != nil {
+			return nil, aiContextError(ctx, timeout, err)
+		}
 	}
 
-	return loaded, nil
+	return nil, fmt.Errorf("AI generation ended unexpectedly")
 }
 
 func aiModel(options *AIOptions) string {
@@ -96,4 +129,41 @@ func validateAITemperature(temperature float64) error {
 	}
 
 	return nil
+}
+
+func aiTimeout(options *AIOptions) (time.Duration, error) {
+	if options != nil && options.Timeout != nil {
+		return validateAITimeout(*options.Timeout)
+	}
+
+	value := strings.TrimSpace(os.Getenv("SYNAPSEQ_AI_TIMEOUT"))
+	if value == "" {
+		return defaultAITimeout, nil
+	}
+
+	timeout, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid SYNAPSEQ_AI_TIMEOUT %q: %w", value, err)
+	}
+
+	return validateAITimeout(timeout)
+}
+
+func validateAITimeout(timeout time.Duration) (time.Duration, error) {
+	if timeout <= 0 {
+		return 0, fmt.Errorf("AI timeout must be greater than zero")
+	}
+
+	return timeout, nil
+}
+
+func aiContextError(ctx context.Context, timeout time.Duration, err error) error {
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return fmt.Errorf("AI generation canceled")
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("AI generation timed out after %s", timeout)
+	}
+
+	return err
 }

--- a/core/ai_test.go
+++ b/core/ai_test.go
@@ -5,10 +5,14 @@
 package core
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestAIValidatesGeneratedSPSQ(ts *testing.T) {
@@ -83,5 +87,129 @@ func TestAITemperatureRejectsInvalidValue(ts *testing.T) {
 
 	if _, err := aiTemperature(nil); err == nil {
 		ts.Fatal("expected invalid temperature error")
+	}
+}
+
+func TestAIContextRepairsInvalidSPSQ(ts *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests++
+		if requests == 2 {
+			var body struct {
+				Messages []struct {
+					Content string `json:"content"`
+				} `json:"messages"`
+			}
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				ts.Errorf("decode repair request: %v", err)
+			}
+			if len(body.Messages) != 2 || !strings.Contains(body.Messages[1].Content, "Validation error") {
+				ts.Errorf("unexpected repair request: %#v", body.Messages)
+			}
+			_, _ = writer.Write([]byte(`{"choices":[{"message":{"content":"relax\n  tone 220 amplitude 10\n00:00:00 relax\n00:10:00 relax"}}]}`))
+			return
+		}
+
+		_, _ = writer.Write([]byte(`{"choices":[{"message":{"content":"not valid spsq"}}]}`))
+	}))
+	defer server.Close()
+	ts.Setenv("SYNAPSEQ_AI_API_KEY", "test-key")
+
+	loaded, err := NewAppContext().AIContext(context.Background(), "make relaxation", &AIOptions{BaseURL: server.URL})
+	if err != nil {
+		ts.Fatalf("AIContext error: %v", err)
+	}
+	if requests != 2 || !strings.Contains(string(loaded.RawContent()), "relax") {
+		ts.Fatalf("unexpected repair result: requests=%d content=%q", requests, loaded.RawContent())
+	}
+}
+
+func TestAIContextStopsAfterTwoRepairs(ts *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests++
+		_, _ = writer.Write([]byte(`{"choices":[{"message":{"content":"not valid spsq"}}]}`))
+	}))
+	defer server.Close()
+	ts.Setenv("SYNAPSEQ_AI_API_KEY", "test-key")
+
+	_, err := NewAppContext().AIContext(context.Background(), "make relaxation", &AIOptions{BaseURL: server.URL})
+	if err == nil || !strings.Contains(err.Error(), "after 2 repair attempts") {
+		ts.Fatalf("unexpected error: %v", err)
+	}
+	if requests != 3 {
+		ts.Fatalf("expected initial request plus two repairs, got %d", requests)
+	}
+}
+
+func TestAIContextDoesNotRepairAPIErrors(ts *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests++
+		writer.WriteHeader(http.StatusInternalServerError)
+		_, _ = writer.Write([]byte(`{"error":{"message":"temporary failure"}}`))
+	}))
+	defer server.Close()
+	ts.Setenv("SYNAPSEQ_AI_API_KEY", "test-key")
+
+	_, err := NewAppContext().AIContext(context.Background(), "make relaxation", &AIOptions{BaseURL: server.URL})
+	if err == nil || !strings.Contains(err.Error(), "HTTP 500") {
+		ts.Fatalf("unexpected error: %v", err)
+	}
+	if requests != 1 {
+		ts.Fatalf("expected one API request, got %d", requests)
+	}
+}
+
+func TestAIContextReportsCancellation(ts *testing.T) {
+	ts.Setenv("SYNAPSEQ_AI_API_KEY", "test-key")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := NewAppContext().AIContext(ctx, "make relaxation", &AIOptions{BaseURL: "http://127.0.0.1:1"})
+	if err == nil || err.Error() != "AI generation canceled" {
+		ts.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAIContextReportsTimeout(ts *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+	}))
+	defer server.Close()
+	ts.Setenv("SYNAPSEQ_AI_API_KEY", "test-key")
+	timeout := 10 * time.Millisecond
+
+	_, err := NewAppContext().AIContext(context.Background(), "make relaxation", &AIOptions{
+		BaseURL: server.URL,
+		Timeout: &timeout,
+	})
+	if err == nil || err.Error() != fmt.Sprintf("AI generation timed out after %s", timeout) {
+		ts.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAITimeoutUsesOptionsBeforeEnvironment(ts *testing.T) {
+	ts.Setenv("SYNAPSEQ_AI_TIMEOUT", "2m")
+	timeout := 30 * time.Second
+
+	got, err := aiTimeout(&AIOptions{Timeout: &timeout})
+	if err != nil {
+		ts.Fatalf("aiTimeout error: %v", err)
+	}
+	if got != timeout {
+		ts.Fatalf("expected option timeout %s, got %s", timeout, got)
+	}
+}
+
+func TestAITimeoutUsesDefault(ts *testing.T) {
+	ts.Setenv("SYNAPSEQ_AI_TIMEOUT", "")
+
+	got, err := aiTimeout(nil)
+	if err != nil {
+		ts.Fatalf("aiTimeout error: %v", err)
+	}
+	if got != defaultAITimeout {
+		ts.Fatalf("expected default timeout %s, got %s", defaultAITimeout, got)
 	}
 }

--- a/core/doc.go
+++ b/core/doc.go
@@ -92,7 +92,9 @@ AI. Model and API host default to gpt-4.1-mini and the OpenAI API; configure a
 local or alternate provider through AIOptions or the SYNAPSEQ_AI_MODEL and
 SYNAPSEQ_AI_BASE_URL environment variables. Set SYNAPSEQ_AI_TEMPERATURE to a
 value from 0 through 2 when the selected model supports custom sampling
-temperature; otherwise leave it unset to use the model default.
+temperature; otherwise leave it unset to use the model default. AI requests
+time out after five minutes by default; configure SYNAPSEQ_AI_TIMEOUT or
+AIOptions.Timeout with a positive time.Duration.
 
 	ctx := synapseq.NewAppContext()
 	loaded, err := ctx.AI("Generate a 10 minute relaxation sequence", &synapseq.AIOptions{
@@ -107,7 +109,9 @@ temperature; otherwise leave it unset to use the model default.
 AI returns an error when the API request fails, the request cannot be
 understood, or the model response is not valid SPSQ. No output file is created
 by this API; callers can inspect RawContent or render the returned
-LoadedContext as usual.
+LoadedContext as usual. AIContext accepts a context.Context for cancellation
+and automatically asks the model to repair invalid SPSQ responses up to two
+times.
 
 # Sequence Inspection
 

--- a/core/example_test.go
+++ b/core/example_test.go
@@ -5,6 +5,7 @@
 package core_test
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -74,6 +75,22 @@ func ExampleAppContext_AI() {
 	}
 
 	// AI validates the response before returning it.
+	fmt.Print(string(loaded.RawContent()))
+}
+
+func ExampleAppContext_AIContext() {
+	if os.Getenv("SYNAPSEQ_AI_API_KEY") == "" {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	loaded, err := synapseq.NewAppContext().AIContext(ctx, "Generate a 10 minute relaxation sequence", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	fmt.Print(string(loaded.RawContent()))
 }
 

--- a/core/types.go
+++ b/core/types.go
@@ -6,6 +6,7 @@ package core
 
 import (
 	"io"
+	"time"
 
 	t "github.com/synapseq-foundation/synapseq/v4/internal/types"
 )
@@ -21,11 +22,13 @@ type AppContext struct {
 // AIOptions configures an OpenAI-compatible model used to generate SPSQ text.
 // Empty Model and BaseURL values use SYNAPSEQ_AI_MODEL and SYNAPSEQ_AI_BASE_URL,
 // then SynapSeq defaults. A nil Temperature uses SYNAPSEQ_AI_TEMPERATURE or
-// omits temperature so the selected model can use its default.
+// omits temperature so the selected model can use its default. A nil Timeout
+// uses SYNAPSEQ_AI_TIMEOUT or the default timeout.
 type AIOptions struct {
 	Model       string
 	BaseURL     string
 	Temperature *float64
+	Timeout     *time.Duration
 }
 
 // LoadedContext holds a loaded sequence and execution settings.

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -80,6 +80,21 @@ func (c *Client) Generate(ctx context.Context, prompt string) (string, error) {
 		return "", fmt.Errorf("AI prompt cannot be empty")
 	}
 
+	return c.generate(ctx, prompt)
+}
+
+func (c *Client) Repair(ctx context.Context, prompt, content string, validationErr error) (string, error) {
+	repairPrompt := fmt.Sprintf(
+		"Original request:\n%s\n\nGenerated SPSQ that failed validation:\n%s\n\nValidation error:\n%s\n\nReturn only corrected valid SPSQ source. Do not include Markdown, explanation, or any text outside SPSQ.",
+		prompt,
+		content,
+		validationErr,
+	)
+
+	return c.generate(ctx, repairPrompt)
+}
+
+func (c *Client) generate(ctx context.Context, prompt string) (string, error) {
 	body, err := json.Marshal(chatCompletionRequest{
 		Model: c.config.Model,
 		Messages: []message{

--- a/internal/ai/client_test.go
+++ b/internal/ai/client_test.go
@@ -7,10 +7,12 @@ package ai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestGenerateSendsOpenAICompatibleRequest(ts *testing.T) {
@@ -108,5 +110,24 @@ func TestNewRequiresAPIKey(ts *testing.T) {
 	_, err := New(Config{Model: "test"})
 	if err == nil || !strings.Contains(err.Error(), "SYNAPSEQ_AI_API_KEY") {
 		ts.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGenerateHonorsContextCancellation(ts *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	client, err := New(Config{APIKey: "test-key", BaseURL: server.URL, Model: "local-model"})
+	if err != nil {
+		ts.Fatalf("New error: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err = client.Generate(ctx, "make a sequence")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		ts.Fatalf("expected context deadline error, got %v", err)
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -94,6 +94,8 @@ type CLIOptions struct {
 	AIBaseURL string
 	// Sampling temperature for AI generation
 	AITemperature string
+	// Maximum duration for AI generation
+	AITimeout string
 }
 
 func init() {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -305,13 +305,14 @@ func TestParseFlagsAI(ts *testing.T) {
 		"-ai-model", "local-model",
 		"-ai-base-url", "http://localhost:1234",
 		"-ai-temperature", "0.2",
+		"-ai-timeout", "90s",
 		"output.spsq",
 	}
 	opts, args, err := ParseFlags()
 	if err != nil {
 		ts.Fatalf("ParseFlags error: %v", err)
 	}
-	if opts.AI != "generate relaxation" || opts.AIModel != "local-model" || opts.AIBaseURL != "http://localhost:1234" || opts.AITemperature != "0.2" {
+	if opts.AI != "generate relaxation" || opts.AIModel != "local-model" || opts.AIBaseURL != "http://localhost:1234" || opts.AITemperature != "0.2" || opts.AITimeout != "90s" {
 		ts.Fatalf("unexpected AI options: %#v", opts)
 	}
 	if len(args) != 1 || args[0] != "output.spsq" {

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -144,6 +144,7 @@ func flagBindings() []flagBinding {
 		{Name: "ai-model", Usage: "OpenAI-compatible model for -ai", ValueKind: flagValueString, BindString: func(opts *CLIOptions) *string { return &opts.AIModel }},
 		{Name: "ai-base-url", Usage: "OpenAI-compatible API host for -ai", ValueKind: flagValueString, BindString: func(opts *CLIOptions) *string { return &opts.AIBaseURL }},
 		{Name: "ai-temperature", Usage: "Sampling temperature for -ai", ValueKind: flagValueString, BindString: func(opts *CLIOptions) *string { return &opts.AITemperature }},
+		{Name: "ai-timeout", Usage: "Maximum duration for -ai", ValueKind: flagValueString, BindString: func(opts *CLIOptions) *string { return &opts.AITimeout }},
 		{Name: "dump", Usage: "Render JSON sequence data", ValueKind: flagValueBool, BindBool: func(opts *CLIOptions) *bool { return &opts.Dump }},
 		{Name: "quiet", Usage: "Enable quiet mode", ValueKind: flagValueBool, BindBool: func(opts *CLIOptions) *bool { return &opts.Quiet }},
 		{Name: "no-color", Usage: "Disable ANSI colors in CLI output", ValueKind: flagValueBool, BindBool: func(opts *CLIOptions) *bool { return &opts.NoColor }},

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -153,10 +153,12 @@ func aiHelpOptions() []helpOption {
 		{FlagText: "-ai-model MODEL", ColumnWidth: 28, Description: "Overrides SYNAPSEQ_AI_MODEL"},
 		{FlagText: "-ai-base-url URL", ColumnWidth: 28, Description: "Overrides SYNAPSEQ_AI_BASE_URL"},
 		{FlagText: "-ai-temperature VALUE", ColumnWidth: 28, Description: "Overrides SYNAPSEQ_AI_TEMPERATURE"},
+		{FlagText: "-ai-timeout DURATION", ColumnWidth: 28, Description: "Overrides SYNAPSEQ_AI_TIMEOUT"},
 		{FlagText: "SYNAPSEQ_AI_API_KEY", ColumnWidth: 28, Description: "Required API key"},
 		{FlagText: "SYNAPSEQ_AI_MODEL", ColumnWidth: 28, Description: "Model name; defaults to gpt-4.1-mini"},
 		{FlagText: "SYNAPSEQ_AI_BASE_URL", ColumnWidth: 28, Description: "OpenAI-compatible API host"},
 		{FlagText: "SYNAPSEQ_AI_TEMPERATURE", ColumnWidth: 28, Description: "Optional sampling temperature from 0 to 2"},
+		{FlagText: "SYNAPSEQ_AI_TIMEOUT", ColumnWidth: 28, Description: "Request timeout; defaults to 5m"},
 	}
 }
 


### PR DESCRIPTION
## Summary
- add cancellation-aware AIContext and configurable generation timeout
- repair invalid SPSQ responses up to two times using parser diagnostics
- add CLI timeout configuration, Ctrl+C cancellation, documentation, and tests

## Testing
- make test