### PR TITLE
refactor: require AI option values

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ set SYNAPSEQ_AI_MODEL=gpt-4.1-mini
 synapseq -ai "Generate a 15 minute focus sequence"
 ```
 
-`SYNAPSEQ_AI_MODEL`, `SYNAPSEQ_AI_BASE_URL`, `SYNAPSEQ_AI_TEMPERATURE`, and `SYNAPSEQ_AI_TIMEOUT` are optional. The default model is `gpt-4.1-mini`, the default API host is OpenAI, and requests time out after five minutes. When temperature is omitted, SynapSeq lets the selected model use its default; this is required by models that do not accept a custom temperature. Use `-ai-model MODEL`, `-ai-base-url URL`, `-ai-temperature VALUE`, and `-ai-timeout DURATION` to override their environment-variable values for one command.
+`SYNAPSEQ_AI_MODEL`, `SYNAPSEQ_AI_BASE_URL`, `SYNAPSEQ_AI_TEMPERATURE`, and `SYNAPSEQ_AI_TIMEOUT` are optional. The default model is `gpt-4.1-mini`, the default API host is OpenAI, CLI temperature is `1`, and requests time out after five minutes. Use `-ai-model MODEL`, `-ai-base-url URL`, `-ai-temperature VALUE`, and `-ai-timeout DURATION` to override their environment-variable values for one command.
 
 SynapSeq validates every response and automatically asks the model to repair invalid SPSQ up to two times. Press `Ctrl+C` to cancel a pending request.
 
@@ -333,7 +333,8 @@ func main() {
 	loaded, err := ctx.AI(context.Background(), "Generate a 10 minute relaxation sequence", &synapseq.AIOptions{
 		Model:   "local-model",
 		BaseURL: "http://localhost:1234",
-		Timeout: durationPtr(90 * time.Second),
+		Temperature: 1,
+		Timeout: 90 * time.Second,
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -343,13 +344,9 @@ func main() {
 		log.Fatal(err)
 	}
 }
-
-func durationPtr(value time.Duration) *time.Duration {
-	return &value
-}
 ```
 
-Omit `AIOptions` to use `SYNAPSEQ_AI_MODEL`, `SYNAPSEQ_AI_BASE_URL`, `SYNAPSEQ_AI_TIMEOUT`, and the default OpenAI configuration. Pass your own `context.Context` to `AppContext.AI` when the calling program needs cancellation. The returned `LoadedContext` is already validated and can also be rendered directly with `loaded.WAV`.
+Set `AIOptions.Temperature` and `AIOptions.Timeout` for the calling application; `SYNAPSEQ_AI_TEMPERATURE` and `SYNAPSEQ_AI_TIMEOUT` are resolved only by the CLI. Omit `Model` or `BaseURL` to use `SYNAPSEQ_AI_MODEL`, `SYNAPSEQ_AI_BASE_URL`, and the default OpenAI configuration. Pass your own `context.Context` to `AppContext.AI` when the calling program needs cancellation. The returned `LoadedContext` is already validated and can also be rendered directly with `loaded.WAV`.
 
 ### SPSQ Builder
 

--- a/cmd/synapseq/ai.go
+++ b/cmd/synapseq/ai.go
@@ -21,6 +21,10 @@ import (
 
 var promptDurationPattern = regexp.MustCompile(`(?i)\b(\d+)\s*(hours?|hrs?|h|minutes?|mins?|m)\b`)
 
+const defaultAITimeout = 5 * time.Minute
+
+const defaultAITemperature = 1
+
 func runAI(ctx context.Context, prompt string, args []string, opts *cli.CLIOptions, statusWriter, outputWriter io.Writer) error {
 	if opts == nil {
 		return fmt.Errorf("CLI options are nil")
@@ -45,11 +49,11 @@ func runAI(ctx context.Context, prompt string, args []string, opts *cli.CLIOptio
 		}
 	}
 
-	temperature, err := cliAITemperature(opts.AITemperature)
+	temperature, err := cliAITemperature(opts.AITemperature, os.Getenv("SYNAPSEQ_AI_TEMPERATURE"))
 	if err != nil {
 		return err
 	}
-	timeout, err := cliAITimeout(opts.AITimeout)
+	timeout, err := cliAITimeout(opts.AITimeout, os.Getenv("SYNAPSEQ_AI_TIMEOUT"))
 	if err != nil {
 		return err
 	}
@@ -86,33 +90,53 @@ func runAI(ctx context.Context, prompt string, args []string, opts *cli.CLIOptio
 	return nil
 }
 
-func cliAITemperature(value string) (*float64, error) {
-	if strings.TrimSpace(value) == "" {
-		return nil, nil
+func cliAITemperature(value, environment string) (float64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		value = strings.TrimSpace(environment)
+	}
+	if value == "" {
+		return defaultAITemperature, nil
 	}
 
 	temperature, err := strconv.ParseFloat(value, 64)
 	if err != nil {
-		return nil, fmt.Errorf("invalid -ai-temperature %q: %w", value, err)
+		return 0, fmt.Errorf("invalid AI temperature %q: %w", value, err)
 	}
 
-	return &temperature, nil
+	if err := validateCLIAITemperature(temperature); err != nil {
+		return 0, err
+	}
+
+	return temperature, nil
 }
 
-func cliAITimeout(value string) (*time.Duration, error) {
-	if strings.TrimSpace(value) == "" {
-		return nil, nil
+func validateCLIAITemperature(temperature float64) error {
+	if temperature < 0 || temperature > 2 {
+		return fmt.Errorf("AI temperature must be between 0 and 2")
+	}
+
+	return nil
+}
+
+func cliAITimeout(value, environment string) (time.Duration, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		value = strings.TrimSpace(environment)
+	}
+	if value == "" {
+		return defaultAITimeout, nil
 	}
 
 	timeout, err := time.ParseDuration(value)
 	if err != nil {
-		return nil, fmt.Errorf("invalid -ai-timeout %q: %w", value, err)
+		return 0, fmt.Errorf("invalid AI timeout %q: %w", value, err)
 	}
 	if timeout <= 0 {
-		return nil, fmt.Errorf("AI timeout must be greater than zero")
+		return 0, fmt.Errorf("AI timeout must be greater than zero")
 	}
 
-	return &timeout, nil
+	return timeout, nil
 }
 
 func aiOutputPath(prompt string) string {

--- a/cmd/synapseq/ai_test.go
+++ b/cmd/synapseq/ai_test.go
@@ -103,30 +103,36 @@ func TestAIOutputPathUsesIntentAndDuration(ts *testing.T) {
 }
 
 func TestCLIAITemperature(ts *testing.T) {
-	temperature, err := cliAITemperature("0.2")
+	temperature, err := cliAITemperature("0.2", "")
 	if err != nil {
 		ts.Fatalf("cliAITemperature error: %v", err)
 	}
-	if temperature == nil || *temperature != 0.2 {
-		ts.Fatalf("unexpected temperature: %#v", temperature)
+	if temperature != 0.2 {
+		ts.Fatalf("unexpected temperature: %v", temperature)
 	}
 
-	if _, err := cliAITemperature("not-a-number"); err == nil {
+	if _, err := cliAITemperature("not-a-number", ""); err == nil {
 		ts.Fatal("expected invalid temperature error")
+	}
+	if temperature, err := cliAITemperature("", ""); err != nil || temperature != defaultAITemperature {
+		ts.Fatalf("expected default temperature, got %v (%v)", temperature, err)
 	}
 }
 
 func TestCLIAITimeout(ts *testing.T) {
-	timeout, err := cliAITimeout("90s")
+	timeout, err := cliAITimeout("90s", "")
 	if err != nil {
 		ts.Fatalf("cliAITimeout error: %v", err)
 	}
-	if timeout == nil || *timeout != 90*time.Second {
-		ts.Fatalf("unexpected timeout: %#v", timeout)
+	if timeout != 90*time.Second {
+		ts.Fatalf("unexpected timeout: %s", timeout)
 	}
 
-	if _, err := cliAITimeout("not-a-duration"); err == nil {
+	if _, err := cliAITimeout("not-a-duration", ""); err == nil {
 		ts.Fatal("expected invalid timeout error")
+	}
+	if timeout, err := cliAITimeout("", ""); err != nil || timeout != defaultAITimeout {
+		ts.Fatalf("expected default timeout, got %s (%v)", timeout, err)
 	}
 }
 

--- a/core/ai.go
+++ b/core/ai.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -19,7 +18,6 @@ import (
 
 const (
 	defaultAIModel   = "gpt-4.1-mini"
-	defaultAITimeout = 5 * time.Minute
 	aiRepairAttempts = 2
 )
 
@@ -34,12 +32,14 @@ func (ac *AppContext) AI(ctx context.Context, prompt string, options *AIOptions)
 	if ctx == nil {
 		return nil, fmt.Errorf("AI context is nil")
 	}
+	if options == nil {
+		return nil, fmt.Errorf("AI options are nil")
+	}
 
-	temperature, err := aiTemperature(options)
-	if err != nil {
+	if err := validateAITemperature(options.Temperature); err != nil {
 		return nil, err
 	}
-	timeout, err := aiTimeout(options)
+	timeout, err := validateAITimeout(options.Timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (ac *AppContext) AI(ctx context.Context, prompt string, options *AIOptions)
 		APIKey:      os.Getenv("SYNAPSEQ_AI_API_KEY"),
 		BaseURL:     aiBaseURL(options),
 		Model:       aiModel(options),
-		Temperature: temperature,
+		Temperature: options.Temperature,
 	})
 	if err != nil {
 		return nil, err
@@ -101,48 +101,12 @@ func aiBaseURL(options *AIOptions) string {
 	return os.Getenv("SYNAPSEQ_AI_BASE_URL")
 }
 
-func aiTemperature(options *AIOptions) (*float64, error) {
-	if options != nil && options.Temperature != nil {
-		return options.Temperature, validateAITemperature(*options.Temperature)
-	}
-
-	value := strings.TrimSpace(os.Getenv("SYNAPSEQ_AI_TEMPERATURE"))
-	if value == "" {
-		return nil, nil
-	}
-
-	temperature, err := strconv.ParseFloat(value, 64)
-	if err != nil {
-		return nil, fmt.Errorf("invalid SYNAPSEQ_AI_TEMPERATURE %q: %w", value, err)
-	}
-
-	return &temperature, validateAITemperature(temperature)
-}
-
 func validateAITemperature(temperature float64) error {
 	if math.IsNaN(temperature) || math.IsInf(temperature, 0) || temperature < 0 || temperature > 2 {
 		return fmt.Errorf("AI temperature must be between 0 and 2")
 	}
 
 	return nil
-}
-
-func aiTimeout(options *AIOptions) (time.Duration, error) {
-	if options != nil && options.Timeout != nil {
-		return validateAITimeout(*options.Timeout)
-	}
-
-	value := strings.TrimSpace(os.Getenv("SYNAPSEQ_AI_TIMEOUT"))
-	if value == "" {
-		return defaultAITimeout, nil
-	}
-
-	timeout, err := time.ParseDuration(value)
-	if err != nil {
-		return 0, fmt.Errorf("invalid SYNAPSEQ_AI_TIMEOUT %q: %w", value, err)
-	}
-
-	return validateAITimeout(timeout)
 }
 
 func validateAITimeout(timeout time.Duration) (time.Duration, error) {

--- a/core/ai_test.go
+++ b/core/ai_test.go
@@ -22,7 +22,7 @@ func TestAIValidatesGeneratedSPSQ(ts *testing.T) {
 	defer server.Close()
 	ts.Setenv("SYNAPSEQ_AI_API_KEY", "test-key")
 
-	loaded, err := NewAppContext().AI(context.Background(), "make sequence", &AIOptions{BaseURL: server.URL})
+	loaded, err := NewAppContext().AI(context.Background(), "make sequence", testAIOptions(server.URL))
 	if err != nil {
 		ts.Fatalf("AI error: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestAIRejectsInvalidSPSQ(ts *testing.T) {
 	defer server.Close()
 	ts.Setenv("SYNAPSEQ_AI_API_KEY", "test-key")
 
-	_, err := NewAppContext().AI(context.Background(), "make sequence", &AIOptions{BaseURL: server.URL})
+	_, err := NewAppContext().AI(context.Background(), "make sequence", testAIOptions(server.URL))
 	if err == nil || !strings.Contains(err.Error(), "AI did not understand the prompt") {
 		ts.Fatalf("unexpected error: %v", err)
 	}
@@ -57,35 +57,14 @@ func TestAIOptionsOverrideEnvironment(ts *testing.T) {
 	}
 }
 
-func TestAITemperatureUsesOptionsBeforeEnvironment(ts *testing.T) {
-	ts.Setenv("SYNAPSEQ_AI_TEMPERATURE", "0.2")
-	temperature := 0.7
-
-	got, err := aiTemperature(&AIOptions{Temperature: &temperature})
-	if err != nil {
-		ts.Fatalf("aiTemperature error: %v", err)
-	}
-	if got == nil || *got != 0.7 {
-		ts.Fatalf("expected option temperature 0.7, got %#v", got)
-	}
-}
-
-func TestAITemperatureUsesEnvironment(ts *testing.T) {
-	ts.Setenv("SYNAPSEQ_AI_TEMPERATURE", "0.2")
-
-	got, err := aiTemperature(nil)
-	if err != nil {
-		ts.Fatalf("aiTemperature error: %v", err)
-	}
-	if got == nil || *got != 0.2 {
-		ts.Fatalf("expected environment temperature 0.2, got %#v", got)
+func TestAIValidatesConfiguredTemperature(ts *testing.T) {
+	if err := validateAITemperature(0.7); err != nil {
+		ts.Fatalf("validateAITemperature error: %v", err)
 	}
 }
 
 func TestAITemperatureRejectsInvalidValue(ts *testing.T) {
-	ts.Setenv("SYNAPSEQ_AI_TEMPERATURE", "3")
-
-	if _, err := aiTemperature(nil); err == nil {
+	if err := validateAITemperature(3); err == nil {
 		ts.Fatal("expected invalid temperature error")
 	}
 }
@@ -115,7 +94,7 @@ func TestAIRepairsInvalidSPSQ(ts *testing.T) {
 	defer server.Close()
 	ts.Setenv("SYNAPSEQ_AI_API_KEY", "test-key")
 
-	loaded, err := NewAppContext().AI(context.Background(), "make sequence", &AIOptions{BaseURL: server.URL})
+	loaded, err := NewAppContext().AI(context.Background(), "make sequence", testAIOptions(server.URL))
 	if err != nil {
 		ts.Fatalf("AI error: %v", err)
 	}
@@ -149,7 +128,7 @@ func TestAIRepairsInvalidSemantics(ts *testing.T) {
 	defer server.Close()
 	ts.Setenv("SYNAPSEQ_AI_API_KEY", "test-key")
 
-	loaded, err := NewAppContext().AI(context.Background(), "Create a gamma session", &AIOptions{BaseURL: server.URL})
+	loaded, err := NewAppContext().AI(context.Background(), "Create a gamma session", testAIOptions(server.URL))
 	if err != nil {
 		ts.Fatalf("AI error: %v", err)
 	}
@@ -167,7 +146,7 @@ func TestAIStopsAfterTwoRepairs(ts *testing.T) {
 	defer server.Close()
 	ts.Setenv("SYNAPSEQ_AI_API_KEY", "test-key")
 
-	_, err := NewAppContext().AI(context.Background(), "make sequence", &AIOptions{BaseURL: server.URL})
+	_, err := NewAppContext().AI(context.Background(), "make sequence", testAIOptions(server.URL))
 	if err == nil || !strings.Contains(err.Error(), "after 2 repair attempts") {
 		ts.Fatalf("unexpected error: %v", err)
 	}
@@ -186,7 +165,7 @@ func TestAIDoesNotRepairAPIErrors(ts *testing.T) {
 	defer server.Close()
 	ts.Setenv("SYNAPSEQ_AI_API_KEY", "test-key")
 
-	_, err := NewAppContext().AI(context.Background(), "make sequence", &AIOptions{BaseURL: server.URL})
+	_, err := NewAppContext().AI(context.Background(), "make sequence", testAIOptions(server.URL))
 	if err == nil || !strings.Contains(err.Error(), "HTTP 500") {
 		ts.Fatalf("unexpected error: %v", err)
 	}
@@ -200,7 +179,7 @@ func TestAIReportsCancellation(ts *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := NewAppContext().AI(ctx, "make sequence", &AIOptions{BaseURL: "http://127.0.0.1:1"})
+	_, err := NewAppContext().AI(ctx, "make sequence", testAIOptions("http://127.0.0.1:1"))
 	if err == nil || err.Error() != "AI generation canceled" {
 		ts.Fatalf("unexpected error: %v", err)
 	}
@@ -216,34 +195,26 @@ func TestAIReportsTimeout(ts *testing.T) {
 
 	_, err := NewAppContext().AI(context.Background(), "make sequence", &AIOptions{
 		BaseURL: server.URL,
-		Timeout: &timeout,
+		Timeout: timeout,
 	})
 	if err == nil || err.Error() != fmt.Sprintf("AI generation timed out after %s", timeout) {
 		ts.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestAITimeoutUsesOptionsBeforeEnvironment(ts *testing.T) {
-	ts.Setenv("SYNAPSEQ_AI_TIMEOUT", "2m")
-	timeout := 30 * time.Second
+func TestAIRejectsMissingTimeout(ts *testing.T) {
+	ts.Setenv("SYNAPSEQ_AI_API_KEY", "test-key")
 
-	got, err := aiTimeout(&AIOptions{Timeout: &timeout})
-	if err != nil {
-		ts.Fatalf("aiTimeout error: %v", err)
-	}
-	if got != timeout {
-		ts.Fatalf("expected option timeout %s, got %s", timeout, got)
+	_, err := NewAppContext().AI(context.Background(), "make sequence", &AIOptions{BaseURL: "http://127.0.0.1:1"})
+	if err == nil || err.Error() != "AI timeout must be greater than zero" {
+		ts.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestAITimeoutUsesDefault(ts *testing.T) {
-	ts.Setenv("SYNAPSEQ_AI_TIMEOUT", "")
-
-	got, err := aiTimeout(nil)
-	if err != nil {
-		ts.Fatalf("aiTimeout error: %v", err)
-	}
-	if got != defaultAITimeout {
-		ts.Fatalf("expected default timeout %s, got %s", defaultAITimeout, got)
+func testAIOptions(baseURL string) *AIOptions {
+	return &AIOptions{
+		BaseURL:     baseURL,
+		Temperature: 1,
+		Timeout:     time.Minute,
 	}
 }

--- a/core/doc.go
+++ b/core/doc.go
@@ -24,6 +24,7 @@ SynapSeq currently supports text input in .spsq format.
 	    "context"
 	    "log"
 	    "os"
+	    "time"
 
 	    synapseq "github.com/synapseq-foundation/synapseq/v4/core"
 	)
@@ -91,16 +92,16 @@ Use AppContext.AI to generate and validate an SPSQ sequence with an
 OpenAI-compatible chat completion API. Set SYNAPSEQ_AI_API_KEY before calling
 AI. Model and API host default to gpt-4.1-mini and the OpenAI API; configure a
 local or alternate provider through AIOptions or the SYNAPSEQ_AI_MODEL and
-SYNAPSEQ_AI_BASE_URL environment variables. Set SYNAPSEQ_AI_TEMPERATURE to a
-value from 0 through 2 when the selected model supports custom sampling
-temperature; otherwise leave it unset to use the model default. AI requests
-time out after five minutes by default; configure SYNAPSEQ_AI_TIMEOUT or
-AIOptions.Timeout with a positive time.Duration.
+SYNAPSEQ_AI_BASE_URL environment variables. Set AIOptions.Temperature to a
+value from 0 through 2 and AIOptions.Timeout to a positive time.Duration
+appropriate for the calling application.
 
 	ctx := synapseq.NewAppContext()
 	loaded, err := ctx.AI(context.Background(), "Generate a 10 minute relaxation sequence", &synapseq.AIOptions{
 	    Model:   "local-model",
 	    BaseURL: "http://localhost:1234",
+	    Temperature: 1,
+	    Timeout: time.Minute,
 	})
 	if err != nil {
 	    log.Fatal(err)

--- a/core/example_test.go
+++ b/core/example_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	synapseq "github.com/synapseq-foundation/synapseq/v4/core"
 )
@@ -67,8 +68,10 @@ func ExampleAppContext_AI() {
 
 	ctx := synapseq.NewAppContext()
 	loaded, err := ctx.AI(context.Background(), "Generate a 10 minute relaxation sequence", &synapseq.AIOptions{
-		Model:   "local-model",
-		BaseURL: "http://localhost:1234",
+		Model:       "local-model",
+		BaseURL:     "http://localhost:1234",
+		Temperature: 1,
+		Timeout:     time.Minute,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/core/types.go
+++ b/core/types.go
@@ -21,14 +21,13 @@ type AppContext struct {
 
 // AIOptions configures an OpenAI-compatible model used to generate SPSQ text.
 // Empty Model and BaseURL values use SYNAPSEQ_AI_MODEL and SYNAPSEQ_AI_BASE_URL,
-// then SynapSeq defaults. A nil Temperature uses SYNAPSEQ_AI_TEMPERATURE or
-// omits temperature so the selected model can use its default. A nil Timeout
-// uses SYNAPSEQ_AI_TIMEOUT or the default timeout.
+// then SynapSeq defaults. Temperature must be between 0 and 2. Timeout must be
+// greater than zero.
 type AIOptions struct {
 	Model       string
 	BaseURL     string
-	Temperature *float64
-	Timeout     *time.Duration
+	Temperature float64
+	Timeout     time.Duration
 }
 
 // LoadedContext holds a loaded sequence and execution settings.

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -22,7 +22,7 @@ type Config struct {
 	APIKey      string
 	BaseURL     string
 	Model       string
-	Temperature *float64
+	Temperature float64
 }
 
 type Client struct {
@@ -33,7 +33,7 @@ type Client struct {
 type chatCompletionRequest struct {
 	Model       string    `json:"model"`
 	Messages    []message `json:"messages"`
-	Temperature *float64  `json:"temperature,omitempty"`
+	Temperature float64   `json:"temperature"`
 }
 
 type message struct {

--- a/internal/ai/client_test.go
+++ b/internal/ai/client_test.go
@@ -37,15 +37,15 @@ func TestGenerateSendsOpenAICompatibleRequest(ts *testing.T) {
 		if body.Messages[1].Content != "make a sequence" {
 			ts.Errorf("unexpected user prompt: %q", body.Messages[1].Content)
 		}
-		if body.Temperature != nil {
-			ts.Errorf("expected default temperature to be omitted, got %v", *body.Temperature)
+		if body.Temperature != 1 {
+			ts.Errorf("expected temperature 1, got %v", body.Temperature)
 		}
 
 		_, _ = writer.Write([]byte(`{"choices":[{"message":{"content":"focus\n  tone 220 amplitude 10\n00:00:00 focus\n00:01:00 focus"}}]}`))
 	}))
 	defer server.Close()
 
-	client, err := New(Config{APIKey: "test-key", BaseURL: server.URL, Model: "local-model"})
+	client, err := New(Config{APIKey: "test-key", BaseURL: server.URL, Model: "local-model", Temperature: 1})
 	if err != nil {
 		ts.Fatalf("New error: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestGenerateSendsConfiguredTemperature(ts *testing.T) {
 		if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
 			ts.Errorf("decode request: %v", err)
 		}
-		if body.Temperature == nil || *body.Temperature != 0.7 {
+		if body.Temperature != 0.7 {
 			ts.Errorf("unexpected temperature: %#v", body.Temperature)
 		}
 
@@ -78,7 +78,7 @@ func TestGenerateSendsConfiguredTemperature(ts *testing.T) {
 		APIKey:      "test-key",
 		BaseURL:     server.URL,
 		Model:       "local-model",
-		Temperature: &temperature,
+		Temperature: temperature,
 	})
 	if err != nil {
 		ts.Fatalf("New error: %v", err)


### PR DESCRIPTION
## Summary
- make core AI temperature and timeout direct values instead of pointers
- keep AI temperature and timeout defaults and environment resolution in the CLI
- simplify public Go examples and update tests

## Testing
- make test