### PR TITLE
feat: support validated custom remote catalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,19 @@ listing, searching, downloading, or generating a remote sequence:
 synapseq -sync
 ```
 
+To sync a self-hosted catalog, pass its base URL. Custom catalogs serve their
+index at `/index.json`, unlike the official catalog's `/free/index.json`:
+
+```bash
+synapseq -sync-url https://my-sequences.com
+```
+
+Set `SYNAPSEQ_REMOTE_BASE_URL` to use that catalog with `-list`, `-search`,
+`-info`, `-download`, and `-get` in later commands. Custom URLs must be a root
+HTTP(S) URL, without a path, credentials, query, or fragment. SynapSeq stores
+each custom catalog in its own cache directory and validates the catalog JSON
+and every downloaded SPSQ file before use.
+
 List all available sequences:
 
 ```bash

--- a/cmd/synapseq/dispatch.go
+++ b/cmd/synapseq/dispatch.go
@@ -33,7 +33,7 @@ func dispatchSpecialCommand(opts *cli.CLIOptions, args []string) (bool, error) {
 		cli.ShowVersion()
 		return true, nil
 	case cli.SpecialCommandSync:
-		return true, remoteRunSync(opts.Quiet)
+		return true, remoteRunSync(opts.RemoteSyncURL, opts.Quiet)
 	case cli.SpecialCommandClean:
 		return true, remoteRunClean(opts.Quiet)
 	case cli.SpecialCommandGet:

--- a/cmd/synapseq/remote.go
+++ b/cmd/synapseq/remote.go
@@ -21,11 +21,22 @@ import (
 const remoteIndexMissingError = "remote index not found. Please run 'synapseq -sync' to fetch the latest Remote index"
 
 // remoteRunSync updates the local Remote index.
-func remoteRunSync(quiet bool) error {
-	if err := remote.RemoteSync(); err != nil {
+func remoteRunSync(baseURL string, quiet bool) error {
+	var err error
+	if baseURL == "" {
+		err = remote.RemoteSync()
+	} else {
+		err = remote.RemoteSyncURL(baseURL)
+	}
+	if err != nil {
 		return fmt.Errorf("failed to sync remote. Error\n  %v", err)
 	}
-	index, err := loadRemoteIndex()
+	var index *t.RemoteIndex
+	if baseURL == "" {
+		index, err = loadRemoteIndex()
+	} else {
+		index, err = remote.GetIndexURL(baseURL)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to get remote index. Error\n  %v", err)
 	}
@@ -179,6 +190,9 @@ func remoteRunInfo(sequenceID string) error {
 	entry := findRemoteEntryByID(index, sequenceID)
 	if entry == nil {
 		return fmt.Errorf("sequence not found: %s", sequenceID)
+	}
+	if _, err := remote.RemoteDownload(entry); err != nil {
+		return fmt.Errorf("failed to download and validate sequence from remote. Error\n  %v", err)
 	}
 
 	printRemoteInfoSummary(entry)

--- a/cmd/synapseq/remote_integration_test.go
+++ b/cmd/synapseq/remote_integration_test.go
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 SynapSeq Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/synapseq-foundation/synapseq/v4/internal/cli"
+	"github.com/synapseq-foundation/synapseq/v4/internal/remote"
+)
+
+const invalidRemoteSequenceIndex = `{
+  "version": "3.0.0",
+  "lastUpdated": "2026-05-13T22:30:42Z",
+  "entries": [{
+    "id": "calm-state",
+    "name": "Calm State",
+    "description": "A test sequence.",
+    "durationMinutes": 15,
+    "sequence": "free/relaxation/calm-state/calm-state.spsq",
+    "artwork": "free/relaxation/calm-state/calm-state.webp",
+    "category": "Relaxation",
+    "createdAt": "2026-03-21T00:00:00Z"
+  }]
+}`
+
+func TestRemoteCommandsRejectInvalidDownloadedSequence(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/index.json":
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(invalidRemoteSequenceIndex))
+		case "/free/relaxation/calm-state/calm-state.spsq":
+			_, _ = writer.Write([]byte("not valid SPSQ"))
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("SYNAPSEQ_REMOTE_BASE_URL", server.URL)
+	if err := remote.RemoteSync(); err != nil {
+		t.Fatalf("RemoteSync error: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "download",
+			run: func() error {
+				return remoteRunDownload("calm-state", t.TempDir(), true)
+			},
+		},
+		{
+			name: "get",
+			run: func() error {
+				return remoteRunGet("calm-state", filepath.Join(t.TempDir(), "calm-state.wav"), &cli.CLIOptions{Quiet: true, Test: true})
+			},
+		},
+		{
+			name: "info",
+			run: func() error {
+				return remoteRunInfo("calm-state")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.run(); err == nil {
+				t.Fatal("expected invalid downloaded SPSQ to be rejected")
+			}
+		})
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -54,6 +54,8 @@ type CLIOptions struct {
 	Play bool
 	// Remote sync index of available sequences
 	RemoteSync bool
+	// Remote sync index from a custom base URL
+	RemoteSyncURL string
 	// Remote clean up local cache
 	RemoteClean bool
 	// Remote list available sequences

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -119,6 +119,12 @@ func TestParseFlags(ts *testing.T) {
 			expectError:  false,
 		},
 		{
+			args:         []string{"cmd", "-sync-url", "https://my-sequences.com"},
+			expected:     &CLIOptions{RemoteSyncURL: "https://my-sequences.com"},
+			expectedArgs: []string{},
+			expectError:  false,
+		},
+		{
 			args:         []string{"cmd", "-clean"},
 			expected:     &CLIOptions{RemoteClean: true},
 			expectedArgs: []string{},
@@ -250,6 +256,9 @@ func TestParseFlags(ts *testing.T) {
 		}
 		if opts.RemoteSync != test.expected.RemoteSync {
 			ts.Errorf("For args %v, RemoteSync: expected %v but got %v", test.args, test.expected.RemoteSync, opts.RemoteSync)
+		}
+		if opts.RemoteSyncURL != test.expected.RemoteSyncURL {
+			ts.Errorf("For args %v, RemoteSyncURL: expected %q but got %q", test.args, test.expected.RemoteSyncURL, opts.RemoteSyncURL)
 		}
 		if opts.RemoteClean != test.expected.RemoteClean {
 			ts.Errorf("For args %v, RemoteClean: expected %v but got %v", test.args, test.expected.RemoteClean, opts.RemoteClean)

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -151,6 +151,7 @@ func flagBindings() []flagBinding {
 		{Name: "test", Usage: "Validate syntax without generating output", ValueKind: flagValueBool, BindBool: func(opts *CLIOptions) *bool { return &opts.Test }},
 		{Name: "help", Usage: "Show help", ValueKind: flagValueBool, BindBool: func(opts *CLIOptions) *bool { return &opts.ShowHelp }},
 		{Name: "sync", Usage: "Sync index of available sequences", ValueKind: flagValueBool, BindBool: func(opts *CLIOptions) *bool { return &opts.RemoteSync }, SpecialCommand: SpecialCommandSync},
+		{Name: "sync-url", Usage: "Sync index from a custom Remote base URL", ValueKind: flagValueString, BindString: func(opts *CLIOptions) *string { return &opts.RemoteSyncURL }, SpecialCommand: SpecialCommandSync},
 		{Name: "clean", Usage: "Clean up local cache", ValueKind: flagValueBool, BindBool: func(opts *CLIOptions) *bool { return &opts.RemoteClean }, SpecialCommand: SpecialCommandClean},
 		{Name: "get", Usage: "Get remote sequence", ValueKind: flagValueString, BindString: func(opts *CLIOptions) *string { return &opts.RemoteGet }, SpecialCommand: SpecialCommandGet},
 		{Name: "list", Usage: "List remote sequences", ValueKind: flagValueBool, BindBool: func(opts *CLIOptions) *bool { return &opts.RemoteList }, SpecialCommand: SpecialCommandList},

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -35,9 +35,7 @@ func Help() {
 	writeOutputSection(writer)
 	writeOptionsSection(writer, "Most common options:", commonHelpOptions())
 	writeAISection(writer)
-	writeMutedLeadSection(writer, "Remote:", "Run -sync first to initialize the local Remote index.")
-	writeOptionsList(writer, remoteHelpOptions())
-	fmt.Fprintln(writer)
+	writeRemoteSection(writer)
 	writeOptionsSection(writer, "Advanced:", advancedHelpOptions())
 
 	if runtime.GOOS == "windows" {
@@ -125,16 +123,22 @@ func writeIndentedOptionsList(writer io.Writer, indent string, options []helpOpt
 func writeAISection(writer io.Writer) {
 	fmt.Fprintf(writer, "%s\n", Section("AI:"))
 	fmt.Fprintf(writer, "  %s\n\n", Muted("Requires SYNAPSEQ_AI_API_KEY."))
-	writeAISubsection(writer, "Command:", aiCommandHelpOptions())
-	writeAISubsection(writer, "Options:", aiConfigurationHelpOptions())
-	writeAISubsection(writer, "Environment:", aiEnvironmentHelpOptions())
+	writeHelpSubsection(writer, "Command:", aiCommandHelpOptions())
+	writeHelpSubsection(writer, "Options:", aiConfigurationHelpOptions())
+	writeHelpSubsection(writer, "Environment:", aiEnvironmentHelpOptions())
 	fmt.Fprintf(writer, "  %s %s\n\n", Label("Priority:"), Muted("-ai-* option > SYNAPSEQ_AI_* environment variable > CLI default"))
 }
 
-func writeAISubsection(writer io.Writer, label string, options []helpOption) {
+func writeHelpSubsection(writer io.Writer, label string, options []helpOption) {
 	fmt.Fprintf(writer, "  %s\n", Label(label))
 	writeIndentedOptionsList(writer, "    ", options)
 	fmt.Fprintln(writer)
+}
+
+func writeRemoteSection(writer io.Writer) {
+	writeMutedLeadSection(writer, "Remote:", "Run -sync first to initialize the local Remote index.")
+	writeHelpSubsection(writer, "Commands:", remoteHelpOptions())
+	writeHelpSubsection(writer, "Environment:", remoteEnvironmentHelpOptions())
 }
 
 func quickStartExamples() []helpExample {
@@ -192,12 +196,19 @@ func aiEnvironmentHelpOptions() []helpOption {
 func remoteHelpOptions() []helpOption {
 	return []helpOption{
 		{FlagText: "-sync", ColumnWidth: 28, Description: "Sync the local Remote index"},
+		{FlagText: "-sync-url URL", ColumnWidth: 28, Description: "Sync a custom Remote base URL"},
 		{FlagText: "-list", ColumnWidth: 28, Description: "List available remote sequences"},
 		{FlagText: "-search WORD", ColumnWidth: 28, Description: "Search remote sequences"},
 		{FlagText: "-info NAME", ColumnWidth: 28, Description: "Show information about a remote sequence"},
 		{FlagText: "-download NAME [DIR]", ColumnWidth: 28, Description: "Download a remote sequence"},
 		{FlagText: "-get NAME [OUTPUT]", ColumnWidth: 28, Description: "Download and generate in one step"},
 		{FlagText: "-clean", ColumnWidth: 28, Description: "Clean up local Remote cache"},
+	}
+}
+
+func remoteEnvironmentHelpOptions() []helpOption {
+	return []helpOption{
+		{FlagText: "SYNAPSEQ_REMOTE_BASE_URL", ColumnWidth: 28, Description: "Custom Remote base URL"},
 	}
 }
 

--- a/internal/remote/cache.go
+++ b/internal/remote/cache.go
@@ -12,6 +12,15 @@ import (
 
 // GetCacheDir returns the path to the cache directory for storing Remote data.
 func GetCacheDir() (string, error) {
+	source, err := defaultRemoteSource()
+	if err != nil {
+		return "", err
+	}
+
+	return getCacheDir(source)
+}
+
+func getCacheDir(source remoteSource) (string, error) {
 	var base string
 
 	switch runtime.GOOS {
@@ -29,6 +38,9 @@ func GetCacheDir() (string, error) {
 		} else {
 			base = filepath.Join(os.Getenv("HOME"), ".cache", "synapseq")
 		}
+	}
+	if source.custom {
+		base = filepath.Join(base, "custom", source.cacheKey)
 	}
 
 	if err := os.MkdirAll(base, 0755); err != nil {

--- a/internal/remote/get.go
+++ b/internal/remote/get.go
@@ -6,12 +6,11 @@ package remote
 
 import (
 	"fmt"
-	"strings"
+	"os"
 
+	"github.com/synapseq-foundation/synapseq/v4/internal/sequence"
 	t "github.com/synapseq-foundation/synapseq/v4/internal/types"
 )
-
-const remoteSequenceRootURL = "https://sequence.synapseq.org"
 
 // RemoteGet retrieves a sequence by its ID from the Remote index.
 func RemoteGet(sequenceID string) (*t.RemoteEntry, error) {
@@ -44,10 +43,13 @@ func RemoteDownload(entry *t.RemoteEntry) (string, error) {
 		return "", err
 	}
 	if cached {
+		if err := validateCachedSequence(entryCache); err != nil {
+			return "", err
+		}
 		return entryCache.sequencePath(), nil
 	}
 
-	if err := downloadEntrySequence(entryCache, entry); err != nil {
+	if err := downloadEntrySequence(cache, entryCache, entry); err != nil {
 		return "", err
 	}
 
@@ -63,14 +65,31 @@ func prepareEntryDownload(cache *remoteCache, entry *t.RemoteEntry) (entryCache,
 	return entryCache, nil
 }
 
-func downloadEntrySequence(cache entryCache, entry *t.RemoteEntry) error {
-	if err := downloadFile(remoteSequenceURL(entry.Sequence), cache.sequencePath()); err != nil {
+func downloadEntrySequence(remoteCache *remoteCache, cache entryCache, entry *t.RemoteEntry) error {
+	data, _, err := downloadURL(remoteCache.source.sequenceURL(entry.Sequence))
+	if err != nil {
+		return fmt.Errorf("error downloading sequence %s: %v", entry.ID, err)
+	}
+	if err := validateRemoteSequence(data, cache.sequencePath(), cache.dir); err != nil {
+		return fmt.Errorf("invalid remote sequence %s: %w", entry.ID, err)
+	}
+	if err := os.WriteFile(cache.sequencePath(), data, 0644); err != nil {
 		return fmt.Errorf("error saving sequence %s: %v", entry.ID, err)
 	}
 
 	return nil
 }
 
-func remoteSequenceURL(sequencePath string) string {
-	return remoteSequenceRootURL + "/" + strings.TrimPrefix(sequencePath, "/")
+func validateCachedSequence(cache entryCache) error {
+	data, err := os.ReadFile(cache.sequencePath())
+	if err != nil {
+		return err
+	}
+
+	return validateRemoteSequence(data, cache.sequencePath(), cache.dir)
+}
+
+func validateRemoteSequence(data []byte, sourceFile, baseRef string) error {
+	_, err := sequence.LoadTextSequence(data, sourceFile, baseRef)
+	return err
 }

--- a/internal/remote/index.go
+++ b/internal/remote/index.go
@@ -4,11 +4,35 @@
 
 package remote
 
-import t "github.com/synapseq-foundation/synapseq/v4/internal/types"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"time"
+
+	t "github.com/synapseq-foundation/synapseq/v4/internal/types"
+)
 
 // GetIndex retrieves and parses the Remote index file from the cache.
 func GetIndex() (*t.RemoteIndex, error) {
 	cache, err := openRemoteCache()
+	if err != nil {
+		return nil, err
+	}
+
+	return cache.index().read()
+}
+
+// GetIndexURL retrieves and parses the index cached for a custom Remote base URL.
+func GetIndexURL(baseURL string) (*t.RemoteIndex, error) {
+	source, err := customRemoteSource(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	cache, err := openRemoteCacheForSource(source)
 	if err != nil {
 		return nil, err
 	}
@@ -24,4 +48,85 @@ func IndexExists() bool {
 	}
 
 	return cache.index().exists()
+}
+
+func parseRemoteIndex(data []byte) (*t.RemoteIndex, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+
+	var index t.RemoteIndex
+	if err := decoder.Decode(&index); err != nil {
+		return nil, fmt.Errorf("invalid remote index: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, fmt.Errorf("invalid remote index: multiple JSON values")
+	}
+
+	if strings.TrimSpace(index.Version) == "" {
+		return nil, fmt.Errorf("invalid remote index: version is required")
+	}
+	if _, err := time.Parse(time.RFC3339, index.LastUpdated); err != nil {
+		return nil, fmt.Errorf("invalid remote index: lastUpdated must be RFC 3339")
+	}
+
+	seenIDs := make(map[string]struct{}, len(index.Entries))
+	for _, entry := range index.Entries {
+		if err := validateRemoteEntry(entry); err != nil {
+			return nil, err
+		}
+		if _, exists := seenIDs[entry.ID]; exists {
+			return nil, fmt.Errorf("invalid remote index: duplicate entry ID %q", entry.ID)
+		}
+		seenIDs[entry.ID] = struct{}{}
+	}
+
+	return &index, nil
+}
+
+func validateRemoteEntry(entry t.RemoteEntry) error {
+	if !validRemoteID(entry.ID) {
+		return fmt.Errorf("invalid remote index: invalid entry ID %q", entry.ID)
+	}
+	if strings.TrimSpace(entry.Name) == "" || strings.TrimSpace(entry.Category) == "" {
+		return fmt.Errorf("invalid remote index: name and category are required for %q", entry.ID)
+	}
+	if entry.DurationMinutes <= 0 {
+		return fmt.Errorf("invalid remote index: durationMinutes must be positive for %q", entry.ID)
+	}
+	if _, err := time.Parse(time.RFC3339, entry.CreatedAt); err != nil {
+		return fmt.Errorf("invalid remote index: createdAt must be RFC 3339 for %q", entry.ID)
+	}
+	if !validRemoteSequencePath(entry.Sequence) {
+		return fmt.Errorf("invalid remote index: invalid sequence path for %q", entry.ID)
+	}
+	if entry.Artwork != "" && !validRemoteRelativePath(entry.Artwork) {
+		return fmt.Errorf("invalid remote index: invalid artwork path for %q", entry.ID)
+	}
+
+	return nil
+}
+
+func validRemoteID(id string) bool {
+	if id == "" || strings.HasPrefix(id, "-") || strings.HasSuffix(id, "-") {
+		return false
+	}
+	for _, char := range id {
+		if char >= 'a' && char <= 'z' || char >= '0' && char <= '9' || char == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func validRemoteSequencePath(value string) bool {
+	return strings.HasSuffix(value, ".spsq") && validRemoteRelativePath(value)
+}
+
+func validRemoteRelativePath(value string) bool {
+	if value == "" || strings.HasPrefix(value, "/") || strings.Contains(value, "\\") || strings.Contains(value, "://") || strings.ContainsAny(value, "?#") {
+		return false
+	}
+
+	return path.Clean(value) == value && !strings.HasPrefix(value, "../") && value != ".."
 }

--- a/internal/remote/remote_test.go
+++ b/internal/remote/remote_test.go
@@ -5,14 +5,68 @@
 package remote
 
 import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	t "github.com/synapseq-foundation/synapseq/v4/internal/types"
 )
+
+//go:embed testdata/index.json
+var customIndexFixture []byte
+
+const validRemoteSPSQ = `entry
+  tone 220 binaural 10 amplitude 10
+00:00:00 entry
+00:00:01 entry
+`
+
+type remoteTestServer struct {
+	index     []byte
+	sequence  []byte
+	requested []string
+}
+
+func newRemoteTestServer() (*remoteTestServer, *httptest.Server) {
+	fixture := &remoteTestServer{index: customIndexFixture, sequence: []byte(validRemoteSPSQ)}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		fixture.requested = append(fixture.requested, request.URL.Path)
+		switch {
+		case request.URL.Path == "/index.json":
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write(fixture.index)
+		case strings.HasSuffix(request.URL.Path, ".spsq"):
+			_, _ = writer.Write(fixture.sequence)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	return fixture, server
+}
+
+func customIndexMutation(ts *testing.T, mutate func(map[string]any)) []byte {
+	ts.Helper()
+	var index map[string]any
+	if err := json.Unmarshal(customIndexFixture, &index); err != nil {
+		ts.Fatalf("unmarshal fixture: %v", err)
+	}
+	mutate(index)
+	data, err := json.Marshal(index)
+	if err != nil {
+		ts.Fatalf("marshal fixture: %v", err)
+	}
+	return data
+}
+
+func fixtureEntry(index map[string]any, position int) map[string]any {
+	return index["entries"].([]any)[position].(map[string]any)
+}
 
 func TestFindEntryByID(ts *testing.T) {
 	index := &t.RemoteIndex{
@@ -42,13 +96,292 @@ func TestIndexCatalogFindEntry(ts *testing.T) {
 	}
 }
 
-func TestRemoteSequenceURL(ts *testing.T) {
-	if got := remoteSequenceURL("/free/focus.spsq"); got != "https://sequence.synapseq.org/free/focus.spsq" {
-		ts.Fatalf("unexpected url: %q", got)
+func TestCustomRemoteSource(ts *testing.T) {
+	source, err := customRemoteSource("https://my-sequences.com:8443/")
+	if err != nil {
+		ts.Fatalf("customRemoteSource error: %v", err)
 	}
-	if got := remoteSequenceURL("free/focus.spsq"); got != "https://sequence.synapseq.org/free/focus.spsq" {
-		ts.Fatalf("unexpected url: %q", got)
+	if source.cacheKey != "my-sequences.com_8443" {
+		ts.Fatalf("unexpected cache key: %q", source.cacheKey)
 	}
+	if got := source.indexURL(); got != "https://my-sequences.com:8443/index.json" {
+		ts.Fatalf("unexpected index URL: %q", got)
+	}
+	if got := source.sequenceURL("focus.spsq"); got != "https://my-sequences.com:8443/focus.spsq" {
+		ts.Fatalf("unexpected sequence URL: %q", got)
+	}
+}
+
+func TestCustomRemoteSourceRejectsNonBaseURL(ts *testing.T) {
+	invalidURLs := []string{
+		"https://my-sequences.com/sequences",
+		"ftp://my-sequences.com",
+		"https://user@my-sequences.com",
+		"https://my-sequences.com?query=value",
+		"https://my-sequences.com#fragment",
+	}
+	for _, rawURL := range invalidURLs {
+		if _, err := customRemoteSource(rawURL); err == nil {
+			ts.Fatalf("expected %q to be rejected", rawURL)
+		}
+	}
+}
+
+func TestDefaultRemoteSourceUsesOfficialIndex(ts *testing.T) {
+	ts.Setenv(remoteBaseURLEnv, "")
+	source, err := defaultRemoteSource()
+	if err != nil {
+		ts.Fatalf("defaultRemoteSource error: %v", err)
+	}
+	if got := source.indexURL(); got != t.RemoteIndexURL {
+		ts.Fatalf("unexpected index URL: %q", got)
+	}
+}
+
+func TestParseRemoteIndex(t *testing.T) {
+	valid := []byte(`{
+  "version": "1",
+  "lastUpdated": "2026-08-01T00:00:00Z",
+  "entries": [{
+    "id": "focus-pack",
+    "name": "Focus Pack",
+    "description": "",
+    "durationMinutes": 15,
+    "sequence": "focus/focus-pack.spsq",
+    "artwork": "focus/focus-pack.webp",
+    "category": "Focus",
+    "createdAt": "2026-08-01T00:00:00Z"
+  }]
+}`)
+	if _, err := parseRemoteIndex(valid); err != nil {
+		t.Fatalf("parseRemoteIndex error: %v", err)
+	}
+
+	invalid := [][]byte{
+		[]byte(`{"version":"1","lastUpdated":"invalid","entries":[]}`),
+		[]byte(`{"version":"1","lastUpdated":"2026-08-01T00:00:00Z","entries":[{"id":"../escape","name":"Escape","durationMinutes":1,"sequence":"escape.spsq","category":"Focus","createdAt":"2026-08-01T00:00:00Z"}]}`),
+		[]byte(`{"version":"1","lastUpdated":"2026-08-01T00:00:00Z","entries":[],"unexpected":true}`),
+	}
+	for _, data := range invalid {
+		if _, err := parseRemoteIndex(data); err == nil {
+			t.Fatalf("expected index to be rejected: %s", data)
+		}
+	}
+}
+
+func TestValidateRemoteSequence(t *testing.T) {
+	valid := []byte("alpha\n  tone 220 binaural 10 amplitude 10\n00:00:00 alpha\n00:00:01 alpha\n")
+	if err := validateRemoteSequence(valid, "focus.spsq", "."); err != nil {
+		t.Fatalf("validateRemoteSequence error: %v", err)
+	}
+	if err := validateRemoteSequence([]byte("not valid"), "focus.spsq", "."); err == nil {
+		t.Fatal("expected invalid SPSQ to be rejected")
+	}
+}
+
+func TestRemoteDownloadRejectsInvalidSequenceWithoutCaching(ts *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/index.json":
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(`{"version":"1","lastUpdated":"2026-08-01T00:00:00Z","entries":[{"id":"focus","name":"Focus","description":"","durationMinutes":1,"sequence":"focus.spsq","category":"Focus","createdAt":"2026-08-01T00:00:00Z"}]}`))
+		case "/focus.spsq":
+			_, _ = writer.Write([]byte("not valid SPSQ"))
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	ts.Setenv(remoteBaseURLEnv, server.URL)
+	ts.Setenv("HOME", ts.TempDir())
+	if err := RemoteSync(); err != nil {
+		ts.Fatalf("RemoteSync error: %v", err)
+	}
+	entry, err := RemoteGet("focus")
+	if err != nil {
+		ts.Fatalf("RemoteGet error: %v", err)
+	}
+	if _, err := RemoteDownload(entry); err == nil {
+		ts.Fatal("expected invalid SPSQ to be rejected")
+	}
+
+	cache, err := openRemoteCache()
+	if err != nil {
+		ts.Fatalf("openRemoteCache error: %v", err)
+	}
+	cached, err := cache.entry(entry).hasSequence()
+	if err != nil {
+		ts.Fatalf("hasSequence error: %v", err)
+	}
+	if cached {
+		ts.Fatal("invalid SPSQ must not be cached")
+	}
+}
+
+func TestCustomRemoteServerSyncsOfficialFormatIndexAndDownloadsSequence(ts *testing.T) {
+	fixture, server := newRemoteTestServer()
+	defer server.Close()
+
+	ts.Setenv("HOME", ts.TempDir())
+	if err := RemoteSyncURL(server.URL); err != nil {
+		ts.Fatalf("RemoteSyncURL error: %v", err)
+	}
+	ts.Setenv(remoteBaseURLEnv, server.URL)
+
+	index, err := GetIndex()
+	if err != nil {
+		ts.Fatalf("GetIndex error: %v", err)
+	}
+	if len(index.Entries) != 3 {
+		ts.Fatalf("expected 3 entries, got %d", len(index.Entries))
+	}
+	entry, err := RemoteGet("calm-state")
+	if err != nil || entry == nil {
+		ts.Fatalf("RemoteGet error: %v, entry: %#v", err, entry)
+	}
+	sequencePath, err := RemoteDownload(entry)
+	if err != nil {
+		ts.Fatalf("RemoteDownload error: %v", err)
+	}
+	content, err := os.ReadFile(sequencePath)
+	if err != nil {
+		ts.Fatalf("read cached sequence: %v", err)
+	}
+	if !bytes.Equal(content, fixture.sequence) {
+		ts.Fatal("cached sequence content differs from server response")
+	}
+	if !slicesContain(fixture.requested, "/index.json") || !slicesContain(fixture.requested, "/free/relaxation/calm-state/calm-state.spsq") {
+		ts.Fatalf("unexpected remote paths: %v", fixture.requested)
+	}
+
+	source, err := customRemoteSource(server.URL)
+	if err != nil {
+		ts.Fatalf("customRemoteSource error: %v", err)
+	}
+	cacheDir, err := getCacheDir(source)
+	if err != nil {
+		ts.Fatalf("getCacheDir error: %v", err)
+	}
+	if !strings.HasSuffix(cacheDir, filepath.Join("custom", source.cacheKey)) {
+		ts.Fatalf("custom cache directory not isolated: %q", cacheDir)
+	}
+}
+
+func TestRemoteSyncRejectsInvalidHostedIndexWithoutReplacingCache(ts *testing.T) {
+	fixture, server := newRemoteTestServer()
+	defer server.Close()
+
+	ts.Setenv("HOME", ts.TempDir())
+	if err := RemoteSyncURL(server.URL); err != nil {
+		ts.Fatalf("initial RemoteSyncURL error: %v", err)
+	}
+	source, err := customRemoteSource(server.URL)
+	if err != nil {
+		ts.Fatalf("customRemoteSource error: %v", err)
+	}
+	cache, err := openRemoteCacheForSource(source)
+	if err != nil {
+		ts.Fatalf("openRemoteCacheForSource error: %v", err)
+	}
+	original, err := os.ReadFile(cache.index().path)
+	if err != nil {
+		ts.Fatalf("read cached index: %v", err)
+	}
+	fixture.index = customIndexMutation(ts, func(index map[string]any) {
+		fixtureEntry(index, 0)["sequence"] = "../escape.spsq"
+	})
+
+	if err := RemoteSyncURL(server.URL); err == nil {
+		ts.Fatal("expected invalid hosted index to be rejected")
+	}
+	after, err := os.ReadFile(cache.index().path)
+	if err != nil {
+		ts.Fatalf("read cached index after rejected sync: %v", err)
+	}
+	if !bytes.Equal(after, original) {
+		ts.Fatal("rejected index must not replace the cached index")
+	}
+}
+
+func TestRemoteSyncRejectsHostedIndexValidationFailures(ts *testing.T) {
+	tests := []struct {
+		name  string
+		index []byte
+	}{
+		{name: "malformed JSON", index: []byte("{")},
+		{name: "unknown field", index: customIndexMutation(ts, func(index map[string]any) { index["unexpected"] = true })},
+		{name: "missing version", index: customIndexMutation(ts, func(index map[string]any) { index["version"] = "" })},
+		{name: "invalid last updated", index: customIndexMutation(ts, func(index map[string]any) { index["lastUpdated"] = "invalid" })},
+		{name: "invalid ID", index: customIndexMutation(ts, func(index map[string]any) { fixtureEntry(index, 0)["id"] = "../escape" })},
+		{name: "duplicate ID", index: customIndexMutation(ts, func(index map[string]any) { fixtureEntry(index, 1)["id"] = fixtureEntry(index, 0)["id"] })},
+		{name: "empty name", index: customIndexMutation(ts, func(index map[string]any) { fixtureEntry(index, 0)["name"] = "" })},
+		{name: "empty category", index: customIndexMutation(ts, func(index map[string]any) { fixtureEntry(index, 0)["category"] = "" })},
+		{name: "non-positive duration", index: customIndexMutation(ts, func(index map[string]any) { fixtureEntry(index, 0)["durationMinutes"] = 0 })},
+		{name: "invalid created at", index: customIndexMutation(ts, func(index map[string]any) { fixtureEntry(index, 0)["createdAt"] = "invalid" })},
+		{name: "absolute sequence", index: customIndexMutation(ts, func(index map[string]any) { fixtureEntry(index, 0)["sequence"] = "/escape.spsq" })},
+		{name: "external sequence", index: customIndexMutation(ts, func(index map[string]any) { fixtureEntry(index, 0)["sequence"] = "https://example.com/escape.spsq" })},
+		{name: "non SPSQ sequence", index: customIndexMutation(ts, func(index map[string]any) { fixtureEntry(index, 0)["sequence"] = "escape.txt" })},
+		{name: "unsafe artwork", index: customIndexMutation(ts, func(index map[string]any) { fixtureEntry(index, 0)["artwork"] = "../escape.webp" })},
+	}
+
+	for _, test := range tests {
+		ts.Run(test.name, func(ts *testing.T) {
+			fixture, server := newRemoteTestServer()
+			defer server.Close()
+			fixture.index = test.index
+			ts.Setenv("HOME", ts.TempDir())
+
+			if err := RemoteSyncURL(server.URL); err == nil {
+				ts.Fatal("expected RemoteSyncURL to reject invalid index")
+			}
+			source, err := customRemoteSource(server.URL)
+			if err != nil {
+				ts.Fatalf("customRemoteSource error: %v", err)
+			}
+			cache, err := openRemoteCacheForSource(source)
+			if err != nil {
+				ts.Fatalf("openRemoteCacheForSource error: %v", err)
+			}
+			if cache.index().exists() {
+				ts.Fatal("invalid index must not be cached")
+			}
+		})
+	}
+}
+
+func TestRemoteDownloadRejectsInvalidCachedSequence(ts *testing.T) {
+	_, server := newRemoteTestServer()
+	defer server.Close()
+
+	ts.Setenv("HOME", ts.TempDir())
+	if err := RemoteSyncURL(server.URL); err != nil {
+		ts.Fatalf("RemoteSyncURL error: %v", err)
+	}
+	ts.Setenv(remoteBaseURLEnv, server.URL)
+	entry, err := RemoteGet("calm-state")
+	if err != nil {
+		ts.Fatalf("RemoteGet error: %v", err)
+	}
+	sequencePath, err := RemoteDownload(entry)
+	if err != nil {
+		ts.Fatalf("RemoteDownload error: %v", err)
+	}
+	if err := os.WriteFile(sequencePath, []byte("invalid SPSQ"), 0644); err != nil {
+		ts.Fatalf("overwrite cached sequence: %v", err)
+	}
+	if _, err := RemoteDownload(entry); err == nil {
+		ts.Fatal("expected invalid cached SPSQ to be rejected")
+	}
+}
+
+func slicesContain(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
 }
 
 func TestDownloadURLRejectsUnexpectedStatus(ts *testing.T) {

--- a/internal/remote/source.go
+++ b/internal/remote/source.go
@@ -1,0 +1,86 @@
+// Copyright (C) 2026 SynapSeq Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package remote
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	t "github.com/synapseq-foundation/synapseq/v4/internal/types"
+)
+
+const remoteBaseURLEnv = "SYNAPSEQ_REMOTE_BASE_URL"
+
+type remoteSource struct {
+	baseURL  string
+	cacheKey string
+	custom   bool
+}
+
+func defaultRemoteSource() (remoteSource, error) {
+	baseURL := strings.TrimSpace(os.Getenv(remoteBaseURLEnv))
+	if baseURL == "" {
+		return remoteSource{baseURL: strings.TrimSuffix(t.RemoteIndexURL, "/free/index.json")}, nil
+	}
+
+	return customRemoteSource(baseURL)
+}
+
+func customRemoteSource(rawURL string) (remoteSource, error) {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return remoteSource{}, fmt.Errorf("invalid remote base URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return remoteSource{}, fmt.Errorf("invalid remote base URL: use http or https")
+	}
+	if parsed.Host == "" {
+		return remoteSource{}, fmt.Errorf("invalid remote base URL: host is required")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Path != "" && parsed.Path != "/" {
+		return remoteSource{}, fmt.Errorf("invalid remote base URL: URL must not include a path, credentials, query, or fragment")
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return remoteSource{}, fmt.Errorf("invalid remote base URL: host is required")
+	}
+	if port := parsed.Port(); port != "" {
+		host += "_" + port
+	}
+	host = cacheSafeName(host)
+
+	return remoteSource{
+		baseURL:  (&url.URL{Scheme: parsed.Scheme, Host: parsed.Host}).String(),
+		cacheKey: host,
+		custom:   true,
+	}, nil
+}
+
+func cacheSafeName(value string) string {
+	var builder strings.Builder
+	for _, char := range value {
+		if char >= 'a' && char <= 'z' || char >= '0' && char <= '9' || char == '.' || char == '-' {
+			builder.WriteRune(char)
+			continue
+		}
+		builder.WriteByte('_')
+	}
+	return builder.String()
+}
+
+func (source remoteSource) indexURL() string {
+	if source.custom {
+		return source.baseURL + "/index.json"
+	}
+
+	return t.RemoteIndexURL
+}
+
+func (source remoteSource) sequenceURL(sequencePath string) string {
+	return source.baseURL + "/" + strings.TrimPrefix(sequencePath, "/")
+}

--- a/internal/remote/storage.go
+++ b/internal/remote/storage.go
@@ -5,7 +5,6 @@
 package remote
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 
@@ -13,7 +12,8 @@ import (
 )
 
 type remoteCache struct {
-	root string
+	root   string
+	source remoteSource
 }
 
 type indexCache struct {
@@ -26,12 +26,21 @@ type entryCache struct {
 }
 
 func openRemoteCache() (*remoteCache, error) {
-	root, err := GetCacheDir()
+	source, err := defaultRemoteSource()
 	if err != nil {
 		return nil, err
 	}
 
-	return &remoteCache{root: root}, nil
+	return openRemoteCacheForSource(source)
+}
+
+func openRemoteCacheForSource(source remoteSource) (*remoteCache, error) {
+	root, err := getCacheDir(source)
+	if err != nil {
+		return nil, err
+	}
+
+	return &remoteCache{root: root, source: source}, nil
 }
 
 func (cache *remoteCache) index() indexCache {
@@ -86,12 +95,7 @@ func readIndexFile(path string) (*t.RemoteIndex, error) {
 		return nil, err
 	}
 
-	var index *t.RemoteIndex
-	if err := json.Unmarshal(indexData, &index); err != nil {
-		return nil, err
-	}
-
-	return index, nil
+	return parseRemoteIndex(indexData)
 }
 
 func writeIndexFile(path string, data []byte) error {

--- a/internal/remote/sync.go
+++ b/internal/remote/sync.go
@@ -4,22 +4,40 @@
 
 package remote
 
-import (
-	t "github.com/synapseq-foundation/synapseq/v4/internal/types"
-)
-
 // RemoteSync updates the local Remote index cache.
 func RemoteSync() error {
-	cache, err := openRemoteCache()
+	source, err := defaultRemoteSource()
 	if err != nil {
 		return err
 	}
 
-	data, response, err := downloadURL(t.RemoteIndexURL)
+	return remoteSync(source)
+}
+
+// RemoteSyncURL updates the cache for a custom Remote base URL.
+func RemoteSyncURL(baseURL string) error {
+	source, err := customRemoteSource(baseURL)
+	if err != nil {
+		return err
+	}
+
+	return remoteSync(source)
+}
+
+func remoteSync(source remoteSource) error {
+	cache, err := openRemoteCacheForSource(source)
+	if err != nil {
+		return err
+	}
+
+	data, response, err := downloadURL(source.indexURL())
 	if err != nil {
 		return err
 	}
 	if err := validateJSONContentType(response); err != nil {
+		return err
+	}
+	if _, err := parseRemoteIndex(data); err != nil {
 		return err
 	}
 

--- a/internal/remote/testdata/index.json
+++ b/internal/remote/testdata/index.json
@@ -1,0 +1,36 @@
+{
+  "version": "3.0.0",
+  "lastUpdated": "2026-05-13T22:30:42Z",
+  "entries": [
+    {
+      "id": "calm-state",
+      "name": "Calm State",
+      "description": "A soothing sequence for a tranquil and relaxed mental state.",
+      "durationMinutes": 15,
+      "sequence": "free/relaxation/calm-state/calm-state.spsq",
+      "artwork": "free/relaxation/calm-state/calm-state.webp",
+      "category": "Relaxation",
+      "createdAt": "2026-03-21T00:00:00Z"
+    },
+    {
+      "id": "alert-flow",
+      "name": "Alert Flow",
+      "description": "A sequence that helps listeners stay alert and focused.",
+      "durationMinutes": 20,
+      "sequence": "free/focus/alert-flow/alert-flow.spsq",
+      "artwork": "free/focus/alert-flow/alert-flow.webp",
+      "category": "Focus",
+      "createdAt": "2026-03-21T00:00:00Z"
+    },
+    {
+      "id": "gamma",
+      "name": "Gamma",
+      "description": "A pure gamma-state binaural sequence.",
+      "durationMinutes": 25,
+      "sequence": "free/pure/gamma/gamma.spsq",
+      "artwork": "free/pure/gamma/gamma.webp",
+      "category": "Pure",
+      "createdAt": "2026-05-10T00:00:00Z"
+    }
+  ]
+}

--- a/internal/types/remote.go
+++ b/internal/types/remote.go
@@ -16,6 +16,7 @@ type RemoteEntry struct {
 	Description     string `json:"description"`
 	DurationMinutes int    `json:"durationMinutes"`
 	Sequence        string `json:"sequence"`
+	Artwork         string `json:"artwork"`
 	Category        string `json:"category"`
 	CreatedAt       string `json:"createdAt"`
 }


### PR DESCRIPTION
## Summary\n- add validated custom Remote catalogs through -sync-url and SYNAPSEQ_REMOTE_BASE_URL\n- isolate custom caches by host and validate Remote indexes and SPSQ content before use\n- add HTTP integration coverage for custom catalog, download, get, and info flows\n\n## Testing\n- make test