### PR TITLE
refactor(spsq)!: require context in builder constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,11 @@ func main() {
 	// Create a new app context with colorized verbose logging
 	ctx := synapseq.NewAppContext().WithVerbose(os.Stderr, true)
 	// Create a new spsq builder with a sample rate of 44100 Hz and volume of 80%
-	builder := spsq.New().SampleRate(44100).Volume(80)
+	builder, err := spsq.New(ctx)
+	if err != nil {
+		panic(err)
+	}
+	builder.SampleRate(44100).Volume(80)
 
 	// Create a new preset for focus mode
 	focus := builder.NewPreset("focus")
@@ -403,7 +407,7 @@ func main() {
 		SilenceAt(5 * time.Minute)
 
 	// Load the sequence into memory
-	loaded, err := timeline.Load(ctx)
+	loaded, err := timeline.Load()
 	if err != nil {
 		panic(err)
 	}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -49,7 +49,7 @@ There are two main paths:
 - a local sequence path, where the CLI loads a user-provided `.spsq` file;
 - a Remote path, where the CLI resolves a remote entry first, downloads it, and then reuses the same loading and rendering pipeline.
 
-Programmatic Go callers can also construct `.spsq` content with `spsq.Builder` and load it through `Builder.Load(ctx)`. From that point on, the content uses the same sequence loading, validation, dumping, and audio rendering pipeline as hand-written text.
+Programmatic Go callers can also construct `.spsq` content with `spsq.New(ctx)` and load it through `Builder.Load()`. From that point on, the content uses the same sequence loading, validation, dumping, and audio rendering pipeline as hand-written text.
 
 ## Package Map
 
@@ -235,7 +235,7 @@ flowchart LR
 
 The most important part of this graph is that `internal/types` stays at the bottom as a shared model package.
 
-At the user-flow level, `spsq.Builder.Load(ctx)` validates generated text through the provided `core.AppContext` and returns the resulting loaded context to the caller.
+At the user-flow level, `spsq.New(ctx)` associates generated text with a `core.AppContext`; `spsq.Builder.Load()` validates it and returns the resulting loaded context to the caller.
 
 ## CLI and Command Dispatch Flow
 
@@ -385,7 +385,7 @@ The public Go API should continue to revolve around the following mental model:
 
 1. Create an `AppContext`.
 2. Optionally configure it with `WithVerbose()`.
-3. Load an `.spsq` file with `LoadFile()` or `LoadContent()` for string sequence content. If the sequence is constructed programmatically, use `spsq.New()` and `Builder.Load(ctx)` to get a `LoadedContext`.
+3. Load an `.spsq` file with `LoadFile()` or `LoadContent()` for string sequence content. If the sequence is constructed programmatically, use `spsq.New(ctx)` and `Builder.Load()` to get a `LoadedContext`.
 4. Use the resulting `LoadedContext` to:
    - inspect comments, sample rate, volume, ambiance, extends, and raw content;
    - render WAV;

--- a/sbg/sbg.go
+++ b/sbg/sbg.go
@@ -51,19 +51,23 @@ func (c *Converter) load(source string, reader io.Reader) (*synapseq.LoadedConte
 	if err != nil {
 		return nil, err
 	}
-	builder, err := build(parsed)
+	builder, err := build(c.ctx, parsed)
 	if err != nil {
 		return nil, err
 	}
-	loaded, err := builder.Load(c.ctx)
+	loaded, err := builder.Load()
 	if err != nil {
 		return nil, fmt.Errorf("validate converted sequence: %w", err)
 	}
 	return loaded, nil
 }
 
-func build(parsed *sequence) (*spsq.Builder, error) {
-	builder := spsq.New().SampleRate(parsed.sampleRate)
+func build(ctx *synapseq.AppContext, parsed *sequence) (*spsq.Builder, error) {
+	builder, err := spsq.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+	builder.SampleRate(parsed.sampleRate)
 	var musicName string
 	if parsed.musicPath != "" {
 		musicPath, err := currentRelativeMusicPath(parsed.musicPath)

--- a/spsq/builder.go
+++ b/spsq/builder.go
@@ -15,6 +15,7 @@ import (
 
 // Builder is responsible for building a sequence from a string sequence content
 type Builder struct {
+	ctx      *synapseq.AppContext
 	timeline []timelineEntry
 	ambiance []ambianceOption
 	music    []musicOption
@@ -48,23 +49,25 @@ type timelineEntry struct {
 	steps      int
 }
 
-// New creates a new Builder
-func New() *Builder {
+// New creates a new Builder using ctx to load generated content.
+func New(ctx *synapseq.AppContext) (*Builder, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context is nil")
+	}
+
 	return &Builder{
+		ctx:      ctx,
 		timeline: make([]timelineEntry, 0),
 		ambiance: make([]ambianceOption, 0),
 		music:    make([]musicOption, 0),
 		options:  make(map[string]string),
 		presets:  make([]presetEntry, 0),
-	}
+	}, nil
 }
 
-// Load renders and loads the generated .spsq content through ctx.
-func (b *Builder) Load(ctx *synapseq.AppContext) (*synapseq.LoadedContext, error) {
-	if ctx == nil {
-		return nil, fmt.Errorf("context is nil")
-	}
-	return ctx.LoadContent(b.content())
+// Load renders and loads the generated .spsq content.
+func (b *Builder) Load() (*synapseq.LoadedContext, error) {
+	return b.ctx.LoadContent(b.content())
 }
 
 // content returns the generated .spsq content as a string.

--- a/spsq/builder_test.go
+++ b/spsq/builder_test.go
@@ -22,7 +22,12 @@ func TestBuilderLoadPreservesOrder(t *testing.T) {
 		}
 	}
 
-	builder := New().
+	ctx := synapseq.NewAppContext()
+	builder, err := New(ctx)
+	if err != nil {
+		t.Fatalf("New error: %v", err)
+	}
+	builder.
 		SampleRate(48000).
 		Volume(80).
 		Ambiance("rain", "rain").
@@ -36,12 +41,11 @@ func TestBuilderLoadPreservesOrder(t *testing.T) {
 	beta := builder.NewPreset("beta")
 	beta.Pink(10).Amplitude(15)
 
-	ctx := synapseq.NewAppContext()
 	loaded, err := builder.
 		SilenceAt(0).
 		PresetAt(15*time.Second, alpha).
 		PresetAt(time.Minute, beta).
-		Load(ctx)
+		Load()
 	if err != nil {
 		t.Fatalf("Load error: %v", err)
 	}
@@ -77,18 +81,21 @@ func TestBuilderLoadPreservesOrder(t *testing.T) {
 }
 
 func TestBuilderLoadReturnsValidationError(t *testing.T) {
-	builder := New()
+	builder, err := New(synapseq.NewAppContext())
+	if err != nil {
+		t.Fatalf("New error: %v", err)
+	}
 	alpha := builder.NewPreset("alpha")
 	alpha.Tone(300).Binaural(10).Amplitude(15)
 
-	_, err := builder.PresetAt(99*time.Minute, alpha).Load(synapseq.NewAppContext())
+	_, err = builder.PresetAt(99*time.Minute, alpha).Load()
 	if err == nil {
 		t.Fatal("expected validation error")
 	}
 }
 
-func TestBuilderLoadRequiresContext(t *testing.T) {
-	_, err := New().Load(nil)
+func TestNewRequiresContext(t *testing.T) {
+	_, err := New(nil)
 	if err == nil {
 		t.Fatal("expected nil context error")
 	}

--- a/spsq/doc.go
+++ b/spsq/doc.go
@@ -29,17 +29,21 @@ audio packages.
 	)
 
 	func main() {
-	    builder := spsq.New().SampleRate(44100).Volume(100)
+	    ctx := synapseq.NewAppContext()
+	    builder, err := spsq.New(ctx)
+	    if err != nil {
+	        log.Fatal(err)
+	    }
+	    builder.SampleRate(44100).Volume(100)
 	    alpha := builder.NewPreset("alpha")
 	    alpha.Pink(0).Amplitude(30)
 	    alpha.Tone(300).Binaural(10).Amplitude(15)
 
-	    ctx := synapseq.NewAppContext()
 	    loaded, err := builder.
 	        SilenceAt(0).
 	        PresetAt(15*time.Second, alpha).
 	        SilenceAt(time.Minute).
-	        Load(ctx)
+	        Load()
 	    if err != nil {
 	        log.Fatal(err)
 	    }
@@ -51,11 +55,21 @@ audio packages.
 
 # Verbose Output
 
-Load receives a core AppContext. Configure that context with WithVerbose when
+New receives a core AppContext. Configure that context with WithVerbose when
 you want progress output from later operations such as WAV, MP3, or Stream:
 
 	ctx := synapseq.NewAppContext().WithVerbose(os.Stderr, true)
-	loaded, err := builder.Load(ctx)
+	builder, err := spsq.New(ctx)
+	if err != nil {
+	    log.Fatal(err)
+	}
+	alpha := builder.NewPreset("alpha")
+	alpha.Pink(0).Amplitude(30)
+	loaded, err := builder.
+		SilenceAt(0).
+		PresetAt(15*time.Second, alpha).
+		SilenceAt(time.Minute).
+		Load()
 	if err != nil {
 	    log.Fatal(err)
 	}
@@ -69,7 +83,7 @@ Typical builder usage follows the .spsq document shape:
   - add sequence options such as sample rate, volume, ambiance, or music;
   - create presets and add tracks with track modifiers;
   - add timeline entries that select presets or silence at specific times;
-  - call Load with a core AppContext to validate and load the generated .spsq content.
+  - call Load to validate and load the generated .spsq content.
 
 Noise tracks are added with White, Pink, or Brown. Each method receives the
 noise smoothness percentage and returns the preset so modifiers such as
@@ -81,7 +95,7 @@ Amplitude can be chained:
 
 Builder methods return the same Builder so calls can be chained. Methods that
 modify the last track or timeline entry are no-ops when there is no matching
-target. Load requires a non-nil core AppContext and returns a core
+target. New requires a non-nil core AppContext. Load returns a core
 LoadedContext or parser and validation errors produced by core.
 
 # More Information

--- a/spsq/example_test.go
+++ b/spsq/example_test.go
@@ -14,17 +14,21 @@ import (
 )
 
 func ExampleNew() {
-	builder := spsq.New().SampleRate(44100).Volume(100)
+	ctx := synapseq.NewAppContext()
+	builder, err := spsq.New(ctx)
+	if err != nil {
+		panic(err)
+	}
+	builder.SampleRate(44100).Volume(100)
 	alpha := builder.NewPreset("alpha")
 	alpha.Pink(0).Amplitude(30)
 	alpha.Tone(300).Binaural(10).Amplitude(15)
 
-	ctx := synapseq.NewAppContext()
 	loaded, err := builder.
 		SilenceAt(0).
 		PresetAt(15*time.Second, alpha).
 		SilenceAt(time.Minute).
-		Load(ctx)
+		Load()
 	if err != nil {
 		panic(err)
 	}
@@ -36,16 +40,19 @@ func ExampleNew() {
 }
 
 func ExampleBuilder_Load_verbose() {
-	builder := spsq.New()
+	ctx := synapseq.NewAppContext().WithVerbose(io.Discard, false)
+	builder, err := spsq.New(ctx)
+	if err != nil {
+		panic(err)
+	}
 	alpha := builder.NewPreset("alpha")
 	alpha.Pink(0).Amplitude(30)
 
-	ctx := synapseq.NewAppContext().WithVerbose(io.Discard, false)
 	loaded, err := builder.
 		SilenceAt(0).
 		PresetAt(15*time.Second, alpha).
 		SilenceAt(time.Minute).
-		Load(ctx)
+		Load()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Summary
- move the SynapSeq application context from `Builder.Load` to `spsq.New`
- update SBaGen conversion, SPSQ tests, examples, and public documentation
- reject nil contexts during builder construction

## Validation
- `make test`