### PR TITLE
chore(release): bump version to 4.41.1

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-4.41.0-foundation
+4.41.1-foundation


### PR DESCRIPTION
Updates the internal SynapSeq version to 4.41.1-foundation for the v4.41.1 release.