### PR TITLE
fix(ci): preserve GPG key listing pipeline

### DIFF
--- a/.github/workflows/publish-package-repository.yml
+++ b/.github/workflows/publish-package-repository.yml
@@ -94,7 +94,7 @@ jobs:
           export GNUPGHOME="$RUNNER_TEMP/gnupg"
           mkdir -m 700 "$GNUPGHOME"
           printf '%s' "$GPG_PACKAGE_SIGNING_KEY_BASE64" | base64 --decode | gpg --batch --import
-          gpg_signing_key="$(gpg --batch --with-colons --list-secret-keys | awk -F: '$1 == "sec" { print $5; exit }')"
+          gpg_signing_key="$(gpg --batch --with-colons --list-secret-keys | awk -F: '$1 == "sec" && !key { key = $5 } END { print key }')"
           test -n "$gpg_signing_key"
 
           # RPM's GPG command reads this protected file instead of opening an interactive pinentry.


### PR DESCRIPTION
## Summary
- avoid closing the GPG key-listing pipe before GPG completes
- allow package repository publication to proceed after private-key import

## Validation
- actionlint .github/workflows/publish-package-repository.yml
- git diff --check