### PR TITLE
fix(ci): validate package signing key

### DIFF
--- a/.github/workflows/publish-package-repository.yml
+++ b/.github/workflows/publish-package-repository.yml
@@ -94,14 +94,24 @@ jobs:
           export GNUPGHOME="$RUNNER_TEMP/gnupg"
           mkdir -m 700 "$GNUPGHOME"
           printf '%s' "$GPG_PACKAGE_SIGNING_KEY_BASE64" | base64 --decode | gpg --batch --import
-          gpg --batch --with-colons --list-secret-keys > "$RUNNER_TEMP/secret-keys.txt"
-          gpg_signing_key="$(awk -F: '$1 == "fpr" && !key { key = $10 } END { print key }' "$RUNNER_TEMP/secret-keys.txt")"
-          test -n "$gpg_signing_key"
+          gpg --batch --with-colons --list-keys > "$RUNNER_TEMP/public-keys.txt"
+          gpg_signing_key="$(awk -F: '$1 == "fpr" && !key { key = $10 } END { print key }' "$RUNNER_TEMP/public-keys.txt")"
+          if [ -z "$gpg_signing_key" ]; then
+            echo "No OpenPGP key was available after import." >&2
+            exit 1
+          fi
+          echo "Using GPG signing key fingerprint: $gpg_signing_key"
 
           # RPM's GPG command reads this protected file instead of opening an interactive pinentry.
           passphrase_file="$RUNNER_TEMP/package-signing-passphrase"
           umask 077
           printf '%s' "$GPG_PACKAGE_SIGNING_PASSPHRASE" > "$passphrase_file"
+          printf 'SynapSeq package repository signing check\n' > "$RUNNER_TEMP/gpg-signing-check.txt"
+          if ! gpg --batch --yes --pinentry-mode loopback --passphrase-file "$passphrase_file" --local-user "$gpg_signing_key" --armor --detach-sign --output "$RUNNER_TEMP/gpg-signing-check.txt.asc" "$RUNNER_TEMP/gpg-signing-check.txt"; then
+            echo "GPG signing check failed. Confirm the private signing subkey and passphrase secrets." >&2
+            exit 1
+          fi
+          gpg --batch --verify "$RUNNER_TEMP/gpg-signing-check.txt.asc" "$RUNNER_TEMP/gpg-signing-check.txt"
           printf '%s\n' \
             '%_signature gpg' \
             "%_gpg_name $gpg_signing_key" \


### PR DESCRIPTION
## Summary
- resolve the signing key from its public-key listing
- validate GPG signing before package repository publication
- provide an actionable failure message for invalid signing secrets

## Validation
- actionlint .github/workflows/publish-package-repository.yml
- git diff --check