### PR TITLE
docs: simplify README and split advanced guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@
   &nbsp;&middot;&nbsp;
   <a href="#synapseq-remote">Remote</a>
   &nbsp;&middot;&nbsp;
-   <a href="#programmatic-api">Go API</a>
+    <a href="docs/GO_API.md">Go API</a>
    &nbsp;&middot;&nbsp;
-   <a href="#generate-spsq-with-ai">AI Generation</a>
+   <a href="docs/AI.md">AI Tools</a>
    &nbsp;&middot;&nbsp;
-   <a href="#use-spsq-with-ai-agents">AI Agents</a>
+   <a href="docs/AI.md#ai-agent-skills">AI Agents</a>
   &nbsp;&middot;&nbsp;
   <a href="docs/SYNTAX.md">Syntax</a>
 </p>
@@ -128,7 +128,8 @@ The official installer identifies the supported distribution, configures the pac
 
 ### Manual Downloads
 
-If you prefer to install manually, download the appropriate archive from the latest GitHub release: [4.41.1](https://github.com/synapseq-foundation/synapseq/releases/tag/v4.41.1).
+If you prefer to install manually, download the appropriate archive from the
+[latest GitHub release](https://github.com/synapseq-foundation/synapseq/releases/latest).
 
 If you want to build SynapSeq from source, see the [Compilation Guide](docs/COMPILE.md).
 
@@ -138,6 +139,8 @@ After installation on any platform, read the repository docs in this order:
 
 - [SYNTAX](docs/SYNTAX.md)
 - [HOW IT WORKS](docs/HOW_IT_WORKS.md)
+- [AI Tools](docs/AI.md), if you want to generate sequences with AI
+- [Go API](docs/GO_API.md), if you want to integrate SynapSeq into a Go application
 
 ## Convert SBaGen Sequences
 
@@ -154,108 +157,15 @@ When the output is omitted, SynapSeq writes a `.spsq` file alongside the source 
 > [!WARNING]
 > SBaGen conversion is experimental. More complex sequences can produce differences or conversion errors because SBaGen and SynapSeq do not have identical sound sources, transition behavior, or media support. Review and validate the generated `.spsq` before using it.
 
-For a Go example using the `sbg` library, see [Programmatic API](#programmatic-api).
+For a Go example using the `sbg` library, see the [Go API Guide](docs/GO_API.md#convert-sbagen-sequences).
 
-## Generate SPSQ With AI
+## AI Tools
 
-Use `-ai` to generate a validated `.spsq` sequence from a natural-language prompt through an OpenAI-compatible API:
+SynapSeq can generate validated SPSQ files through OpenAI-compatible APIs and
+provides skills for AI coding agents.
 
-```bash
-export SYNAPSEQ_AI_API_KEY="your-api-key"
-synapseq -ai "Generate a 10 minute relaxation sequence"
-```
-
-When no output path is given, SynapSeq creates a descriptive new `.spsq` file in the current directory. Supply a path to choose the destination, or `-` to write only SPSQ content to standard output:
-
-```bash
-synapseq -ai "Generate a 30 minute study sequence" study-30m.spsq
-synapseq -ai "Generate a 20 minute meditation sequence" -
-```
-
-SynapSeq requires `SYNAPSEQ_AI_API_KEY` and validates every model response before writing it. Invalid or unrecognized responses return an error and never create an output file. Existing destination files are not overwritten.
-
-Use an OpenAI-compatible local or remote model with environment variables:
-
-```bash
-export SYNAPSEQ_AI_API_KEY="local-key"
-export SYNAPSEQ_AI_MODEL="google/gemma-4-e4b"
-export SYNAPSEQ_AI_BASE_URL="http://localhost:1234"
-export SYNAPSEQ_AI_TEMPERATURE="0.2"
-export SYNAPSEQ_AI_TIMEOUT="90s"
-synapseq -ai "Generate a 15 minute focus sequence"
-```
-
-### Windows Environment Variables
-
-In PowerShell, set the variables for the current session before invoking SynapSeq:
-
-```powershell
-$env:SYNAPSEQ_AI_API_KEY = "your-api-key"
-$env:SYNAPSEQ_AI_MODEL = "gpt-4.1-mini"
-synapseq -ai "Generate a 15 minute focus sequence"
-```
-
-In Command Prompt, use `set` instead:
-
-```bat
-set SYNAPSEQ_AI_API_KEY=your-api-key
-set SYNAPSEQ_AI_MODEL=gpt-4.1-mini
-synapseq -ai "Generate a 15 minute focus sequence"
-```
-
-`SYNAPSEQ_AI_MODEL`, `SYNAPSEQ_AI_BASE_URL`, `SYNAPSEQ_AI_TEMPERATURE`, and `SYNAPSEQ_AI_TIMEOUT` are optional. The default model is `gpt-4.1-mini`, the default API host is OpenAI, CLI temperature is `1`, and requests time out after five minutes. Use `-ai-model MODEL`, `-ai-base-url URL`, `-ai-temperature VALUE`, and `-ai-timeout DURATION` to override their environment-variable values for one command.
-
-SynapSeq validates every response and automatically asks the model to repair invalid SPSQ up to two times. Press `Ctrl+C` to cancel a pending request.
-
-For English prompts containing `delta`, `theta`, `alpha`, `beta`, `gamma`, `sleep`, `meditation`, `focus`, or `relaxation`, SynapSeq also validates the generated beat ranges, audible carriers, and required profile progression before writing the sequence. These checks are sound-design constraints and do not promise a listener outcome.
-
-To generate SPSQ through the public Go API, see [AI Generation From Go](#ai-generation-from-go).
-
-## Use SPSQ With AI Agents
-
-SynapSeq publishes three complementary [skills](https://skills.sh/synapseq-foundation/synapseq) for AI coding agents:
-
-| Skill | Use it to | Result | Existing files |
-|-------|-----------|--------|----------------|
-| [`create-spsq`](https://skills.sh/synapseq-foundation/synapseq/create-spsq) | Create a sequence from scratch or derive a new version from a reference | A new validated `.spsq` file | Never modified or overwritten |
-| [`explain-spsq`](https://skills.sh/synapseq-foundation/synapseq/explain-spsq) | Learn SPSQ syntax or understand how an existing sequence behaves | A didactic, read-only explanation | Never modified |
-| [`review-spsq`](https://skills.sh/synapseq-foundation/synapseq/review-spsq) | Audit syntax, semantics, sound structure, and timeline composition | A read-only report with prioritized findings | Never modified |
-
-Choose by the main action: **create**, **explain**, or **review**. The skills can hand work to one another through self-contained prompts, but only `create-spsq` writes complete sequence files, always at a new path.
-
-### Install
-
-Install all SynapSeq skills with the [`skills` CLI](https://github.com/vercel-labs/skills):
-
-```bash
-npx skills add synapseq-foundation/synapseq
-```
-
-The command installs the complete skill suite and lets you choose the target agent and installation scope.
-
-### Codex
-
-Mention the skill explicitly according to the task:
-
-```text
-$create-spsq Create a 20-minute relaxation sequence with a smooth binaural fade-in and fade-out.
-$explain-spsq Explain the presets, tracks, and timeline in focus.spsq.
-$review-spsq Audit focus.spsq and report technical, structural, and artistic findings.
-```
-
-You can also describe the task normally; Codex may select the skill automatically when the request matches its description.
-
-### Claude Code
-
-Invoke the installed skill as a slash command:
-
-```text
-/create-spsq Create a 20-minute relaxation sequence with a smooth binaural fade-in and fade-out.
-/explain-spsq Explain the presets, tracks, and timeline in focus.spsq.
-/review-spsq Audit focus.spsq and report technical, structural, and artistic findings.
-```
-
-Claude Code can also load a skill automatically when a request matches its description. Explicit invocation is the most predictable option for both agents. Install SynapSeq using the [Quick Start](#quick-start) instructions when the agent needs to validate a local file with `synapseq -test`.
+See the [AI Guide](docs/AI.md) for CLI configuration, local models, Codex,
+Claude Code, and the `create-spsq`, `explain-spsq`, and `review-spsq` skills.
 
 ## SynapSeq Remote
 
@@ -266,18 +176,8 @@ listing, searching, downloading, or generating a remote sequence:
 synapseq -sync
 ```
 
-To sync a self-hosted catalog, pass its base URL. Custom catalogs serve their
-index at `/index.json`, unlike the official catalog's `/free/index.json`:
-
-```bash
-synapseq -sync-url https://my-sequences.com
-```
-
-Set `SYNAPSEQ_REMOTE_BASE_URL` to use that catalog with `-list`, `-search`,
-`-info`, `-download`, and `-get` in later commands. Custom URLs must be a root
-HTTP(S) URL, without a path, credentials, query, or fragment. SynapSeq stores
-each custom catalog in its own cache directory and validates the catalog JSON
-and every downloaded SPSQ file before use.
+For self-hosted catalogs and advanced repository configuration, see the
+[Remote Guide](docs/REMOTE.md).
 
 List all available sequences:
 
@@ -331,131 +231,13 @@ Or with `.mp3` extension:
 synapseq -get calm-state calm-state.mp3
 ```
 
-## Programmatic API
+## Go API
 
-The public Go API can construct the same `.spsq` representation in code and pass it through the regular loading, validation, and rendering pipeline:
+The public Go API can construct, validate, convert, and render the same
+`.spsq` representation used by the CLI.
 
-### AI Generation From Go
-
-`AppContext.AI` generates and validates SPSQ through an OpenAI-compatible API. Set `SYNAPSEQ_AI_API_KEY` before calling it; `AIOptions` can select a local model, API host, or timeout:
-
-```go
-package main
-
-import (
-	"context"
-	"log"
-	"os"
-	"time"
-
-	synapseq "github.com/synapseq-foundation/synapseq/v4/core"
-)
-
-func main() {
-	ctx := synapseq.NewAppContext()
-	loaded, err := ctx.AI(context.Background(), "Generate a 10 minute relaxation sequence", &synapseq.AIOptions{
-		Model:   "local-model",
-		BaseURL: "http://localhost:1234",
-		Temperature: 1,
-		Timeout: 90 * time.Second,
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if err := os.WriteFile("relaxation.spsq", loaded.RawContent(), 0o644); err != nil {
-		log.Fatal(err)
-	}
-}
-```
-
-Set `AIOptions.Temperature` and `AIOptions.Timeout` for the calling application; `SYNAPSEQ_AI_TEMPERATURE` and `SYNAPSEQ_AI_TIMEOUT` are resolved only by the CLI. Omit `Model` or `BaseURL` to use `SYNAPSEQ_AI_MODEL`, `SYNAPSEQ_AI_BASE_URL`, and the default OpenAI configuration. Pass your own `context.Context` to `AppContext.AI` when the calling program needs cancellation. The returned `LoadedContext` is already validated and can also be rendered directly with `loaded.WAV`.
-
-### SPSQ Builder
-
-Use the builder API to construct an SPSQ sequence programmatically:
-
-```go
-package main
-
-import (
-	"fmt"
-	"os"
-	"time"
-
-	synapseq "github.com/synapseq-foundation/synapseq/v4/core"
-	"github.com/synapseq-foundation/synapseq/v4/spsq"
-)
-
-func main() {
-	// Create a new app context with colorized verbose logging
-	ctx := synapseq.NewAppContext().WithVerbose(os.Stderr, true)
-	// Create a new spsq builder with a sample rate of 44100 Hz and volume of 80%
-	builder, err := spsq.New(ctx)
-	if err != nil {
-		panic(err)
-	}
-	builder.SampleRate(44100).Volume(80)
-
-	// Create a new preset for focus mode
-	focus := builder.NewPreset("focus")
-	// Add tone with 220 Hz, binaural with 12 Hz, and amplitude of 25%
-	focus.Tone(220).Binaural(12).Amplitude(25)
-	// Add pink noise with 15% of smoothness and amplitude of 12%
-	focus.Pink(15).Amplitude(12)
-
-	// Create the timeline
-	timeline := builder.
-		// Fade in 00:00:00
-		SilenceAt(0).
-		// Focus preset starts at 00:00:15
-		PresetAt(15*time.Second, focus).
-		// Focus preset ends at 00:04:30
-		PresetAt(4*time.Minute+30*time.Second, focus).
-		// Fade out at 00:05:00
-		SilenceAt(5 * time.Minute)
-
-	// Load the sequence into memory
-	loaded, err := timeline.Load()
-	if err != nil {
-		panic(err)
-	}
-
-	// Print the spsq sequence
-	fmt.Println(string(loaded.RawContent()))
-
-	// Save the sequence as a WAV file
-	if err := loaded.WAV("output.wav"); err != nil {
-		panic(err)
-	}
-}
-```
-
-### Convert SBaGen Sequences
-
-The `sbg` package provides the same SBaGen conversion flow in Go:
-
-```go
-ctx := synapseq.NewAppContext()
-converter, err := sbg.New(ctx)
-if err != nil {
-    panic(err)
-}
-
-loaded, err := converter.LoadFile("session.sbg")
-if err != nil {
-    panic(err)
-}
-
-content := loaded.RawContent()
-```
-
-Use `converter.LoadContent(sbgContent)` when the SBaGen source text is already available in memory.
-
-Docs:
-- [core](https://pkg.go.dev/github.com/synapseq-foundation/synapseq/v4/core)
-- [spsq](https://pkg.go.dev/github.com/synapseq-foundation/synapseq/v4/spsq)
-- [sbg](https://pkg.go.dev/github.com/synapseq-foundation/synapseq/v4/sbg)
+See the [Go API Guide](docs/GO_API.md) for examples covering AI generation,
+the SPSQ builder, and SBaGen conversion.
 
 ## Contributing
 
@@ -469,63 +251,18 @@ SynapSeq is distributed under the GPL v3 or later license. See the [COPYING](COP
 
 ### Third-Party Licenses
 
-All original code in SynapSeq is licensed under the GNU GPL v3 or later, but the following components are included and redistributed under their respective terms:
-
-- **[fatih/color](https://github.com/fatih/color)**  
-  License: MIT  
-  Used for colorized terminal output.
-
-- **[beep](https://github.com/gopxl/beep)**  
-  License: MIT  
-  Used for audio encoding/decoding.
-
-- **[golang.org/x/sys](https://pkg.go.dev/golang.org/x/sys)**  
-  License: BSD 3-Clause  
-  Used for platform-specific system integration.
-
-- **[go-colorable](https://github.com/mattn/go-colorable)**  
-  License: MIT  
-  Used indirectly for cross-platform ANSI color support.
-
-- **[go-isatty](https://github.com/mattn/go-isatty)**  
-  License: MIT  
-  Used indirectly for terminal capability detection.
-
-- **[pkg/errors](https://github.com/pkg/errors)**  
-  License: BSD 2-Clause  
-  Used indirectly for error wrapping and stack trace utilities.
-
-All third-party copyright notices and licenses are preserved in this repository in compliance with their original terms.
+See [Third-Party Licenses](docs/THIRD_PARTY_LICENSES.md) for the licenses of
+bundled dependencies.
 
 ## Contact
 
 We'd love to hear from you! Here's how to get in touch:
 
-### Issues (Bug Reports & Feature Requests)
+Use [GitHub Issues](https://github.com/synapseq-foundation/synapseq/issues) for
+bugs, feature requests, and documentation improvements.
 
-Use [GitHub Issues](https://github.com/synapseq-foundation/synapseq/issues) for:
-
-- Bug reports and technical problems
-- Feature requests and enhancement suggestions
-- Documentation improvements
-
-### Discussions (Questions & Community)
-
-Use [GitHub Discussions](https://github.com/synapseq-foundation/synapseq/discussions) for:
-
-- General questions and support (e.g., "How do I use `@extends`?")
-- Help with your sequences (e.g., "My sequence isn't working, can you help?")
-- Sharing your own sequences and presets with the community
-- Discussing ideas and best practices
-- Showcasing creative use cases
-
-### Quick Guidelines
-
-- **Found a bug?** → Open an Issue
-- **Want a new feature?** → Open an Issue
-- **Need help or have questions?** → Start a Discussion
-- **Want to share your sequences?** → Post in Discussions
-- **General feedback or ideas?** → Start a Discussion
+Use [GitHub Discussions](https://github.com/synapseq-foundation/synapseq/discussions)
+for questions, support, sequence sharing, and ideas.
 
 ## Credits
 

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -1,0 +1,124 @@
+# AI Tools
+
+SynapSeq supports SPSQ generation through OpenAI-compatible APIs and provides
+three skills for AI coding agents.
+
+## Generate SPSQ From The CLI
+
+Use `-ai` with an OpenAI-compatible API:
+
+```bash
+export SYNAPSEQ_AI_API_KEY="your-api-key"
+synapseq -ai "Generate a 10 minute relaxation sequence"
+```
+
+Choose an output path, or use `-` to write only SPSQ content to standard
+output:
+
+```bash
+synapseq -ai "Generate a 30 minute study sequence" study-30m.spsq
+synapseq -ai "Generate a 20 minute meditation sequence" -
+```
+
+SynapSeq validates every model response before writing it. Invalid responses
+are repaired automatically up to two times; if validation still fails, no
+output file is created. Existing destination files are never overwritten.
+
+### Configuration
+
+The default model is `gpt-4.1-mini`, the default API host is OpenAI, the CLI
+temperature is `1`, and requests time out after five minutes.
+
+```bash
+export SYNAPSEQ_AI_API_KEY="local-key"
+export SYNAPSEQ_AI_MODEL="google/gemma-4-e4b"
+export SYNAPSEQ_AI_BASE_URL="http://localhost:1234"
+export SYNAPSEQ_AI_TEMPERATURE="0.2"
+export SYNAPSEQ_AI_TIMEOUT="90s"
+synapseq -ai "Generate a 15 minute focus sequence"
+```
+
+The same settings can be provided as CLI flags:
+
+```text
+-ai-model MODEL
+-ai-base-url URL
+-ai-temperature VALUE
+-ai-timeout DURATION
+```
+
+On Windows, set the variables in PowerShell:
+
+```powershell
+$env:SYNAPSEQ_AI_API_KEY = "your-api-key"
+$env:SYNAPSEQ_AI_MODEL = "gpt-4.1-mini"
+synapseq -ai "Generate a 15 minute focus sequence"
+```
+
+Or in Command Prompt:
+
+```bat
+set SYNAPSEQ_AI_API_KEY=your-api-key
+set SYNAPSEQ_AI_MODEL=gpt-4.1-mini
+synapseq -ai "Generate a 15 minute focus sequence"
+```
+
+For English prompts containing terms such as `delta`, `theta`, `alpha`,
+`beta`, `gamma`, `sleep`, `meditation`, `focus`, or `relaxation`, SynapSeq
+also validates beat ranges, audible carriers, and required profile
+progression. These are sound-design constraints, not promises about listener
+outcomes.
+
+For the equivalent Go API, see the [Go API Guide](GO_API.md#ai-generation-from-go).
+
+## AI Agent Skills
+
+SynapSeq publishes three complementary
+[skills](https://skills.sh/synapseq-foundation/synapseq) for AI coding agents:
+
+| Skill | Use it to | Result | Existing files |
+|-------|-----------|--------|----------------|
+| [`create-spsq`](https://skills.sh/synapseq-foundation/synapseq/create-spsq) | Create a sequence or derive a new version from a reference | A new validated `.spsq` file | Never modified or overwritten |
+| [`explain-spsq`](https://skills.sh/synapseq-foundation/synapseq/explain-spsq) | Learn syntax or understand an existing sequence | A didactic, read-only explanation | Never modified |
+| [`review-spsq`](https://skills.sh/synapseq-foundation/synapseq/review-spsq) | Audit syntax, semantics, sound structure, and timeline composition | A prioritized read-only report | Never modified |
+
+Choose the skill by the main action: **create**, **explain**, or **review**.
+Only `create-spsq` writes complete sequence files, and it always writes to a
+new path.
+
+### Install
+
+Install the complete skill suite with the [`skills` CLI](https://github.com/vercel-labs/skills):
+
+```bash
+npx skills add synapseq-foundation/synapseq
+```
+
+The command lets you choose the target agent and installation scope.
+
+### Codex
+
+Mention the skill explicitly:
+
+```text
+$create-spsq Create a 20-minute relaxation sequence with a smooth binaural fade-in and fade-out.
+$explain-spsq Explain the presets, tracks, and timeline in focus.spsq.
+$review-spsq Audit focus.spsq and report technical, structural, and artistic findings.
+```
+
+Codex may also select a skill automatically when the request matches its
+description.
+
+### Claude Code
+
+Invoke an installed skill as a slash command:
+
+```text
+/create-spsq Create a 20-minute relaxation sequence with a smooth binaural fade-in and fade-out.
+/explain-spsq Explain the presets, tracks, and timeline in focus.spsq.
+/review-spsq Audit focus.spsq and report technical, structural, and artistic findings.
+```
+
+Claude Code can also load a skill automatically. Explicit invocation is the
+most predictable option. Install SynapSeq using the [Quick Start](../README.md#quick-start)
+instructions when the agent needs to validate a local file with `synapseq -test`.

--- a/docs/COMPILE.md
+++ b/docs/COMPILE.md
@@ -98,7 +98,7 @@ make --version
 If you have not cloned the project yet:
 
 ```bash
-git clone https://github.com/ruanklein/synapseq.git
+git clone https://github.com/synapseq-foundation/synapseq.git
 cd synapseq
 ```
 

--- a/docs/GO_API.md
+++ b/docs/GO_API.md
@@ -1,0 +1,126 @@
+# Go API
+
+SynapSeq exposes a public Go API for generating, validating, converting, and
+rendering sequences programmatically. The public packages are documented on
+[`pkg.go.dev`](https://pkg.go.dev/github.com/synapseq-foundation/synapseq/v4).
+
+## AI Generation From Go
+
+`AppContext.AI` generates and validates SPSQ through an OpenAI-compatible API.
+Set `SYNAPSEQ_AI_API_KEY` before calling it. `AIOptions` can select a local
+model, API host, temperature, or timeout:
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+
+	synapseq "github.com/synapseq-foundation/synapseq/v4/core"
+)
+
+func main() {
+	ctx := synapseq.NewAppContext()
+	loaded, err := ctx.AI(context.Background(), "Generate a 10 minute relaxation sequence", &synapseq.AIOptions{
+		Model:       "local-model",
+		BaseURL:     "http://localhost:1234",
+		Temperature: 1,
+		Timeout:     90 * time.Second,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := os.WriteFile("relaxation.spsq", loaded.RawContent(), 0o644); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+`AIOptions.Temperature` and `AIOptions.Timeout` belong to the calling
+application. The CLI-only environment variables `SYNAPSEQ_AI_TEMPERATURE` and
+`SYNAPSEQ_AI_TIMEOUT` are not resolved automatically by the Go API.
+
+Omit `Model` or `BaseURL` to use `SYNAPSEQ_AI_MODEL`,
+`SYNAPSEQ_AI_BASE_URL`, and the default OpenAI configuration. Pass a custom
+`context.Context` to `AppContext.AI` when the application needs cancellation.
+The returned `LoadedContext` is already validated and can also be rendered
+with `loaded.WAV`.
+
+## SPSQ Builder
+
+The builder API constructs an SPSQ sequence in code and sends it through the
+regular loading, validation, and rendering pipeline:
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	synapseq "github.com/synapseq-foundation/synapseq/v4/core"
+	"github.com/synapseq-foundation/synapseq/v4/spsq"
+)
+
+func main() {
+	ctx := synapseq.NewAppContext().WithVerbose(os.Stderr, true)
+	builder, err := spsq.New(ctx)
+	if err != nil {
+		panic(err)
+	}
+	builder.SampleRate(44100).Volume(80)
+
+	focus := builder.NewPreset("focus")
+	focus.Tone(220).Binaural(12).Amplitude(25)
+	focus.Pink(15).Amplitude(12)
+
+	timeline := builder.
+		SilenceAt(0).
+		PresetAt(15*time.Second, focus).
+		PresetAt(4*time.Minute+30*time.Second, focus).
+		SilenceAt(5 * time.Minute)
+
+	loaded, err := timeline.Load()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(loaded.RawContent()))
+	if err := loaded.WAV("output.wav"); err != nil {
+		panic(err)
+	}
+}
+```
+
+## Convert SBaGen Sequences
+
+The `sbg` package provides the SBaGen conversion flow in Go:
+
+```go
+ctx := synapseq.NewAppContext()
+converter, err := sbg.New(ctx)
+if err != nil {
+	panic(err)
+}
+
+loaded, err := converter.LoadFile("session.sbg")
+if err != nil {
+	panic(err)
+}
+
+content := loaded.RawContent()
+```
+
+Use `converter.LoadContent(sbgContent)` when the SBaGen source text is already
+available in memory.
+
+## Packages
+
+- [`core`](https://pkg.go.dev/github.com/synapseq-foundation/synapseq/v4/core) - public application context and loaded sequences.
+- [`spsq`](https://pkg.go.dev/github.com/synapseq-foundation/synapseq/v4/spsq) - programmatic SPSQ builder.
+- [`sbg`](https://pkg.go.dev/github.com/synapseq-foundation/synapseq/v4/sbg) - SBaGen conversion.

--- a/docs/REMOTE.md
+++ b/docs/REMOTE.md
@@ -1,0 +1,21 @@
+# SynapSeq Remote
+
+SynapSeq Remote provides ready-to-use sequences through a local catalog index.
+
+## Custom Catalogs
+
+Advanced users can sync a self-hosted catalog by passing its base URL:
+
+```bash
+synapseq -sync-url https://my-sequences.com
+```
+
+Custom catalogs serve their index at `/index.json`, unlike the official
+catalog's `/free/index.json`.
+
+Set `SYNAPSEQ_REMOTE_BASE_URL` to use the custom catalog with `-list`,
+`-search`, `-info`, `-download`, and `-get` in later commands. Custom URLs must
+be root HTTP(S) URLs without a path, credentials, query, or fragment.
+
+SynapSeq stores each custom catalog in its own cache directory and validates
+the catalog JSON and every downloaded SPSQ file before use.

--- a/docs/THIRD_PARTY_LICENSES.md
+++ b/docs/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,15 @@
+# Third-Party Licenses
+
+All original code in SynapSeq is licensed under the GNU GPL v3 or later. The
+following components are included and redistributed under their respective
+terms:
+
+- **[fatih/color](https://github.com/fatih/color)** - MIT; colorized terminal output.
+- **[beep](https://github.com/gopxl/beep)** - MIT; audio encoding and decoding.
+- **[golang.org/x/sys](https://pkg.go.dev/golang.org/x/sys)** - BSD 3-Clause; platform-specific system integration.
+- **[go-colorable](https://github.com/mattn/go-colorable)** - MIT; cross-platform ANSI color support.
+- **[go-isatty](https://github.com/mattn/go-isatty)** - MIT; terminal capability detection.
+- **[pkg/errors](https://github.com/pkg/errors)** - BSD 2-Clause; error wrapping and stack trace utilities.
+
+All third-party copyright notices and licenses are preserved in this
+repository in compliance with their original terms.


### PR DESCRIPTION
## Summary\n\n- Simplify the README for end users.\n- Move Go API, AI tooling, and third-party license details into focused guides.\n- Move custom SynapSeq Remote catalog configuration into an advanced guide.\n- Fix the compilation guide repository URL and use the latest release link.\n\n## Validation\n\n- git diff --check