### PR TITLE
feat: use track waveforms for doppler

### DIFF
--- a/.agents/skills/create-spsq/SKILL.md
+++ b/.agents/skills/create-spsq/SKILL.md
@@ -51,7 +51,7 @@ Treat focus, sleep, relaxation, meditation, and similar terms as creative listen
 5. Use `smooth` for rounded changes, `steady` for linear changes, and `ease-in` or `ease-out` only when their directional behavior is intentional.
 6. Add steps only for a deliberate back-and-forth trajectory. Ensure the interval is long enough for every leg.
 7. Use a template only when two or more playable presets share a base containing multiple tracks and each variant changes only a small subset of parameters. Define presets directly when there is only one variant, only one simple track, most parameters change, or the source/effect types or channel layout differ.
-8. Keep amplitudes conservative unless the user supplied exact values. When setting distinct left/right amplitudes, use them deliberately as final post-pan channel balance; avoid stacking many high-amplitude tracks merely to make a sequence sound stronger.
+8. Keep amplitudes conservative unless the user supplied exact values. When setting distinct left/right amplitudes, use them deliberately as final post-pan channel balance; avoid stacking many high-amplitude tracks merely to make a sequence sound stronger. Select non-sine waveforms for `doppler` deliberately because they also shape its pitch movement.
 
 Do not invent ambiance or music assets. Use only paths, URLs, or named resources supplied by the user or already present in the sequence and its `.spsc` dependencies. If a requested external layer has no source, ask for it or omit that layer and say so.
 

--- a/.agents/skills/create-spsq/references/spsq-language.md
+++ b/.agents/skills/create-spsq/references/spsq-language.md
@@ -125,7 +125,7 @@ Indent every track with exactly two ASCII spaces.
 
 Built-in waveforms are `sine` (default), `square`, `triangle`, and `sawtooth`; a declared custom waveform name is accepted in the same position. Tone effects are `pan`, `modulation`, and `doppler`. When present, tokens must occur in the shown order: optional beat, optional effect, `intensity`, then `amplitude`.
 
-The waveform shapes pure, binaural, and monaural oscillators. On isochronic tracks, the same waveform shapes both the carrier and gate. Compatible timeline changes morph between custom and built-in tables while retaining phase. Sharp custom segments can add harmonics and aliasing because tables are not band-limited.
+The waveform shapes pure, binaural, and monaural oscillators. On isochronic tracks, the same waveform shapes both the carrier and gate. It also shapes pan, modulation, and doppler motion. Compatible timeline changes morph between custom and built-in tables while retaining phase. Sharp custom segments can add harmonics and aliasing because tables are not band-limited.
 
 `amplitude VALUE` sets both channels. `amplitude left LEFT right RIGHT` sets final channel percentages independently; `left` always requires `right`. Both values range from `0` through `100` and are applied after `pan`.
 

--- a/.agents/skills/explain-spsq/SKILL.md
+++ b/.agents/skills/explain-spsq/SKILL.md
@@ -56,7 +56,7 @@ Run only one applicable command. Validation is evidence for the explanation, not
    - a plain-language overview of the sound and total duration;
    - top-level options, comments, declared resources, custom waveform definitions, and extends;
    - each playable preset and template, including inherited overrides and effective track order;
-   - what each track contributes: source, rhythm or beat, waveform, left/right amplitude when asymmetric, smoothness, and effects;
+   - what each track contributes: source, rhythm or beat, waveform, left/right amplitude when asymmetric, smoothness, and effects, including waveform-shaped doppler motion;
    - a chronological phase table with interval duration, active preset, transition, steps, and the change toward the next entry;
    - fades, incompatible-channel crossfades, repeated presets, and the role of `silence`;
    - the expected perceptual progression and practical listening notes relevant to the question.

--- a/.agents/skills/explain-spsq/references/spsq-language.md
+++ b/.agents/skills/explain-spsq/references/spsq-language.md
@@ -112,7 +112,7 @@ Normal presets must contain tracks, directly or through inheritance. Preset name
 - `isochronic` gates a tone on and off at the stated rate, creating a pronounced pulse.
 - Built-in waveforms are `sine` (default), `square`, `triangle`, and `sawtooth`. A custom name may be used after a valid `@waveform` definition.
 - Custom values map `0 -> -1`, `50 -> 0`, and `100 -> +1`. Points are equally spaced and linearly joined around the cycle, including final-to-first interpolation.
-- The waveform shapes pure, binaural, and monaural oscillators. Isochronic tracks use it for both carrier and gate. Pan and modulation can also use it; doppler remains sine-based.
+- The waveform shapes pure, binaural, and monaural oscillators. Isochronic tracks use it for both carrier and gate. Pan, modulation, and doppler also use it for their motion.
 - Compatible transitions morph normally between any custom or built-in pair while preserving phase. Sharp segments may add harmonics or aliasing; avoid claiming an exact subjective effect.
 
 Carrier and beat values must be non-negative. Binaural and monaural values must remain below twice the carrier so their lower component stays positive.

--- a/.agents/skills/review-spsq/SKILL.md
+++ b/.agents/skills/review-spsq/SKILL.md
@@ -114,7 +114,7 @@ A commented line resembling an option, such as `# @volume 60`, is not automatica
 
 ## Review sound and timeline responsibly
 
-Assess simultaneous tracks, nearby carriers, multiple beat methods, left/right amplitudes and their post-pan balance, noise density, competing movement effects, waveform character, masking, contrast, abrupt changes, long static phases, entrances, development, landing, and final fade.
+Assess simultaneous tracks, nearby carriers, multiple beat methods, left/right amplitudes and their post-pan balance, noise density, competing movement effects, waveform character, including its effect on doppler motion, masking, contrast, abrupt changes, long static phases, entrances, development, landing, and final fade.
 
 Do not:
 

--- a/.agents/skills/review-spsq/references/review-checklist.md
+++ b/.agents/skills/review-spsq/references/review-checklist.md
@@ -132,6 +132,7 @@ Check:
 - external resource names match declarations.
 - custom points are interpreted as evenly spaced bipolar values (`0 -> -1`, `50 -> 0`, `100 -> +1`) with circular linear interpolation;
 - an isochronic custom waveform intentionally shapes both its carrier and gate, not only the pulse envelope;
+- a non-sine waveform on a tone with `doppler` intentionally shapes the pitch movement as well as the source waveform;
 - waveform prefixes on ambiance/music affect pan or modulation motion, not the external PCM itself.
 
 Do not invent unsupported codecs, effects, source types, or implied parameters.

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -149,7 +149,7 @@ The waveform has several roles:
 - pure, binaural, and monaural tones use it as their oscillator shape;
 - isochronic tracks use the same shape for both the audible carrier and the pulse gate;
 - pan and modulation use it as their motion shape, including on ambiance and music;
-- doppler motion remains sine-based;
+- pan, modulation, and doppler motion use the selected waveform;
 - compatible timeline changes morph linearly between the old and new waveform while preserving oscillator phase.
 
 The engine performs this compilation before rendering and uses integer table IDs in the sample loop. Custom waveforms are not band-limited. Steep segments, sharp corners, and high carrier frequencies can therefore emphasize harmonics or aliasing, much like square and sawtooth waves. Phase alignment also matters when morphing between differently oriented shapes.

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -277,7 +277,7 @@ Noise lines can describe white, pink, or brown noise, optionally with `smooth`, 
 
 Ambiance lines reference a named ambiance option and then define amplitude, with optional supported effects. The current parser also accepts a leading `waveform` token before ambiance declarations, even though waveform selection is primarily a tone-oriented concept.
 
-For tones, the selected waveform shapes pure, binaural, and monaural oscillators. On an isochronic track, the same waveform shapes both the carrier and the rhythmic gate. For ambiance and music, it does not reshape the external PCM; it affects waveform-driven `pan` or `modulation`. Doppler always uses its built-in sine motion.
+For tones, the selected waveform shapes pure, binaural, and monaural oscillators. On an isochronic track, the same waveform shapes both the carrier and the rhythmic gate. It also shapes waveform-driven `pan`, `modulation`, and `doppler` motion. For ambiance and music, it does not reshape the external PCM; it affects waveform-driven `pan` or `modulation`.
 
 Music lines reference a named music option and use the same amplitude/effect forms as ambiance. Music is finite: when the file ends, that channel becomes silent and rendering continues until the sequence timeline ends.
 

--- a/internal/audio/effects/doppler.go
+++ b/internal/audio/effects/doppler.go
@@ -7,7 +7,6 @@ package effects
 import (
 	"math"
 
-	wt "github.com/synapseq-foundation/synapseq/v4/internal/audio/wavetable"
 	t "github.com/synapseq-foundation/synapseq/v4/internal/types"
 )
 
@@ -17,7 +16,7 @@ func (p *Processor) ApplyDoppler(channel *t.Channel, effect t.Effect, increment 
 	}
 
 	p.advanceEffectPhase(channel)
-	factor := p.calcDopplerFactor(channel.Effect.Offset, effect.Intensity)
+	factor := p.calcDopplerFactor(WaveformMorphFromChannel(channel), channel.Effect.Offset, effect.Intensity)
 	return int(math.Round(float64(increment) * factor))
 }
 
@@ -27,11 +26,11 @@ func (p *Processor) ApplyDopplerPair(channel *t.Channel, effect t.Effect, inc0, 
 	}
 
 	p.advanceEffectPhase(channel)
-	factor := p.calcDopplerFactor(channel.Effect.Offset, effect.Intensity)
+	factor := p.calcDopplerFactor(WaveformMorphFromChannel(channel), channel.Effect.Offset, effect.Intensity)
 	return int(math.Round(float64(inc0) * factor)), int(math.Round(float64(inc1) * factor))
 }
 
-func (p *Processor) calcDopplerFactor(offset int, intensity t.IntensityType) float64 {
+func (p *Processor) calcDopplerFactor(waveform WaveformMorph, offset int, intensity t.IntensityType) float64 {
 	inten := float64(intensity)
 	if inten < 0 {
 		inten = 0
@@ -40,8 +39,7 @@ func (p *Processor) calcDopplerFactor(offset int, intensity t.IntensityType) flo
 		inten = 1
 	}
 
-	lfo := p.waveTables[int(wt.SineID)][offset>>16]
-	lfoNorm := float64(lfo) / float64(t.WaveTableAmplitude)
+	lfoNorm := p.WaveformValueForMorph(waveform, offset) / float64(t.WaveTableAmplitude)
 
 	depth := 0.05 * inten
 	return 1.0 + (depth * lfoNorm)

--- a/internal/audio/effects/doppler_test.go
+++ b/internal/audio/effects/doppler_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"testing"
 
+	wt "github.com/synapseq-foundation/synapseq/v4/internal/audio/wavetable"
 	t "github.com/synapseq-foundation/synapseq/v4/internal/types"
 )
 
@@ -33,8 +34,49 @@ func TestApplyDopplerPairAdvancesPhaseAndScalesBothChannels(ts *testing.T) {
 	if channel.Effect.Offset != step {
 		ts.Fatalf("unexpected doppler phase advance: got %d, want %d", channel.Effect.Offset, step)
 	}
-	factor := processor.calcDopplerFactor(step, 1)
+	factor := processor.calcDopplerFactor(WaveformMorph{}, step, 1)
 	if left != int(math.Round(100*factor)) || right != int(math.Round(200*factor)) {
 		ts.Fatalf("unexpected doppler pair output: got [%d %d], want [%d %d]", left, right, int(math.Round(100*factor)), int(math.Round(200*factor)))
+	}
+}
+
+func TestApplyDopplerUsesTrackWaveform(ts *testing.T) {
+	processor := newTestProcessor()
+	channel := &t.Channel{
+		Track:  t.Track{Waveform: t.WaveformSquare},
+		Effect: t.EffectState{Increment: t.PhasePrecision},
+	}
+
+	got := processor.ApplyDoppler(channel, t.Effect{Type: t.EffectDoppler, Intensity: 1}, 100)
+	if got != 105 {
+		ts.Fatalf("unexpected square-wave doppler increment: got %d, want 105", got)
+	}
+
+	sineFactor := processor.calcDopplerFactor(
+		WaveformMorph{Start: wt.SineID, End: wt.SineID},
+		t.PhasePrecision,
+		1,
+	)
+	if got == int(math.Round(100*sineFactor)) {
+		ts.Fatalf("doppler ignored the track waveform: got %d", got)
+	}
+}
+
+func TestApplyDopplerMorphsTrackWaveforms(ts *testing.T) {
+	processor := newTestProcessor()
+	channel := &t.Channel{
+		WaveformStart: int(wt.SineID),
+		WaveformEnd:   int(wt.SquareID),
+		WaveformAlpha: 0.5,
+		Effect:        t.EffectState{Increment: t.PhasePrecision},
+	}
+
+	got := processor.ApplyDoppler(channel, t.Effect{Type: t.EffectDoppler, Intensity: 1}, 100)
+	sine := float64(processor.waveTables[int(wt.SineID)][1])
+	square := float64(processor.waveTables[int(wt.SquareID)][1])
+	waveformValue := sine + (square-sine)*0.5
+	want := int(math.Round(100 * (1 + 0.05*waveformValue/float64(t.WaveTableAmplitude))))
+	if got != want {
+		ts.Fatalf("unexpected morphed doppler increment: got %d, want %d", got, want)
 	}
 }

--- a/internal/audio/effects/waveform_test.go
+++ b/internal/audio/effects/waveform_test.go
@@ -31,7 +31,7 @@ func TestWaveformValueForMorphInterpolatesBetweenTables(ts *testing.T) {
 	}
 }
 
-func TestCustomWaveformDrivesSamplingModulationAndPan(ts *testing.T) {
+func TestCustomWaveformDrivesSamplingAndEffects(ts *testing.T) {
 	registry, err := wt.Compile([]t.WaveformDefinition{{Name: "pulse", Points: []float64{-1, 1}}})
 	if err != nil {
 		ts.Fatalf("Compile error: %v", err)
@@ -67,5 +67,12 @@ func TestCustomWaveformDrivesSamplingModulationAndPan(ts *testing.T) {
 	)
 	if left != 0 || right != 1000 {
 		ts.Fatalf("unexpected custom waveform pan output: got [%d %d]", left, right)
+	}
+
+	channel.WaveformStart = int(id)
+	channel.WaveformEnd = int(id)
+	channel.Effect = t.EffectState{Increment: highPhase}
+	if got := processor.ApplyDoppler(channel, t.Effect{Type: t.EffectDoppler, Intensity: 1}, 100); got != 105 {
+		ts.Fatalf("unexpected custom waveform doppler increment: got %d, want 105", got)
 	}
 }


### PR DESCRIPTION
## Summary\n- drive Doppler pitch motion from the track waveform and waveform morph\n- cover square and custom waveforms in the effects tests\n- synchronize SPSQ documentation and skills\n\n## Validation\n- make test\n- git diff --check