### PR TITLE
feat: add custom timeline transitions

### DIFF
--- a/.agents/skills/create-spsq/references/spsq-language.md
+++ b/.agents/skills/create-spsq/references/spsq-language.md
@@ -44,6 +44,7 @@ Supported top-level forms:
 @music bed audio/meditation
 @music theme
 @waveform softpulse 0 0 20 60 100 60 20 0
+@transition soft-land 0 2 12 42 78 96 100
 @extends presets/base
 ```
 
@@ -53,6 +54,7 @@ Supported top-level forms:
 - A local `@extends` path resolves to `.spsc`, not `.spsq`.
 - `.spsc` files use the same options and preset syntax but cannot contain timeline entries or another `@extends`.
 - Custom waveform definitions require 2 through 16384 decimal points in the range `0..100`. Their names are case-sensitive, unique across the merged sequence, and cannot be `sine`, `square`, `triangle`, or `sawtooth` in any letter case.
+- Custom transition definitions require 2 through 256 non-decreasing decimal points in `0..100`, beginning at `0` and ending at `100`. Names are case-sensitive, unique across the merged sequence, and cannot be `steady`, `ease-in`, `ease-out`, or `smooth` in any letter case.
 
 Local paths:
 
@@ -184,7 +186,7 @@ Example:
 - The first entry must be `00:00:00`; every later timestamp must strictly increase.
 - A valid sequence needs at least two timeline entries.
 - Timeline entries must reference existing, non-template presets. Built-in `silence` is always available.
-- Transitions are `steady` (default), `ease-in`, `ease-out`, and `smooth`.
+- Transitions are `steady` (default), `ease-in`, `ease-out`, `smooth`, or a declared custom transition name.
 
 The transition and steps on one timeline entry control the interval from that entry toward the next entry. Values interpolate across compatible tracks aligned by channel/declaration order.
 
@@ -197,6 +199,8 @@ max steps = min(12, max(0, floor((floor(D / 5) - 1) / 2)))
 Examples: 10 seconds permits `0`, 15 seconds permits `1`, 25 seconds permits `2`, and 55 seconds permits `5`.
 
 `silence -> active` and `active -> silence` become fade-compatible boundaries. Incompatible source types, effects, ambiance names, or music names on the same channel use automatic per-channel crossfades of up to 30 seconds on each available side. `active -> off` and `off -> active` use equivalent boundary fades. No timeline entries are inserted.
+
+A custom transition linearly interpolates between its equally spaced points for compatible changes and silence fades. It is reapplied to every `steps` leg. Automatic incompatible-channel crossfades remain linear.
 
 For generated sessions, use built-in `silence` only at the timeline boundaries:
 

--- a/.agents/skills/explain-spsq/references/spsq-language.md
+++ b/.agents/skills/explain-spsq/references/spsq-language.md
@@ -45,6 +45,7 @@ Supported top-level forms include:
 @ambiance rain audio/rain
 @music bed audio/meditation
 @waveform softpulse 0 0 20 60 100 60 20 0
+@transition soft-land 0 2 12 42 78 96 100
 @extends presets/base
 ```
 
@@ -57,6 +58,7 @@ Supported top-level forms include:
 - Local `@extends` resolves to an `.spsc` file.
 - Remote resources must resolve as WAV or MP3 by extension or MIME type.
 - `@waveform` defines one reusable cycle with 2 through 16384 decimal points from `0` through `100`. Names are case-sensitive, unique across extensions, and cannot conflict case-insensitively with a built-in waveform.
+- `@transition` defines a reusable interpolation curve with 2 through 256 non-decreasing decimal points from `0` through `100`; its first and last points must be `0` and `100`. Names are case-sensitive, unique across extensions, and cannot conflict case-insensitively with a built-in transition.
 
 Options lock when preset, track, override, or timeline content begins. Resource declarations must precede tracks that reference them.
 
@@ -178,8 +180,9 @@ Transitions:
 - `ease-in` starts gently and accelerates.
 - `ease-out` starts more quickly and settles gently.
 - `smooth` eases at both ends.
+- A declared custom transition name follows its evenly spaced points; it applies to compatible changes and silence fades, while automatic incompatible-channel crossfades stay linear.
 
-Steps create an alternating forward/backward trajectory before finally arriving at the next state. There are `2 × steps + 1` legs, each needing at least five seconds, with a hard cap of 12 steps. Explain steps as repeated oscillation between endpoint tendencies, not as additional timeline entries.
+Steps create an alternating forward/backward trajectory before finally arriving at the next state. There are `2 × steps + 1` legs, each needing at least five seconds, with a hard cap of 12 steps. A custom transition curve is reapplied on every leg. Explain steps as repeated oscillation between endpoint tendencies, not as additional timeline entries.
 
 ### Silence and fades
 

--- a/.agents/skills/review-spsq/references/review-checklist.md
+++ b/.agents/skills/review-spsq/references/review-checklist.md
@@ -49,6 +49,7 @@ Accepted options are:
 - `@ambiance NAME [PATH-OR-URL]`;
 - `@music NAME [PATH-OR-URL]`;
 - `@waveform NAME POINT POINT [POINT ...]`;
+- `@transition NAME POINT POINT [POINT ...]`;
 - `@extends PATH-OR-URL`.
 
 Check:
@@ -58,6 +59,7 @@ Check:
 - resource names are valid and unique where required;
 - every ambiance/music track references a declaration;
 - every declaration that appears intended for playback is actually referenced;
+- each custom transition has 2 through 256 non-decreasing `0..100` points, starts at `0`, ends at `100`, and does not use a built-in transition name;
 - local paths are relative, use `/`, contain no `..`, spaces, backslashes, roots, drive prefixes, or extensions;
 - local ambiance resolves `.wav` before `.mp3`;
 - local music resolves `.mp3` before `.wav`;
@@ -152,11 +154,11 @@ Check:
 - timestamps strictly increase;
 - at least two entries exist;
 - every referenced preset exists and is playable;
-- transitions are `steady`, `ease-in`, `ease-out`, or `smooth`;
+- transitions are `steady`, `ease-in`, `ease-out`, `smooth`, or a declared custom transition;
 - steps are non-negative, at most 12, and fit the interval;
 - total duration equals the final timestamp.
 
-The transition and steps on an entry control the interval toward the next entry. Steps create `2 × steps + 1` alternating legs, each requiring at least five seconds.
+The transition and steps on an entry control the interval toward the next entry. Steps create `2 × steps + 1` alternating legs, each requiring at least five seconds. A custom curve repeats on each leg; automatic incompatible-channel crossfades remain linear.
 
 Review:
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ SynapSeq is best understood as a **creative and experimental audio tool**. It gi
 - optional independent left/right track amplitudes;
 - spatial movement and modulation through effects;
 - reusable custom periodic waveforms defined as amplitude points;
+- reusable custom timeline-transition curves defined as interpolation points;
 - repeatable sessions rendered as WAV, streamed as PCM, played directly, or converted to MP3;
 - reusable presets and sequences extended from other `.spsc` files.
 

--- a/core/generate.go
+++ b/core/generate.go
@@ -47,6 +47,7 @@ func (lc *LoadedContext) buildAudioRendererOptions(sequence *t.Sequence) *audio.
 		StatusOutput: lc.appCtx.statusOutput,
 		Colors:       lc.appCtx.statusColors,
 		Waveforms:    sequence.Waveforms,
+		Transitions:  sequence.Transitions,
 	}
 }
 

--- a/core/sequence.go
+++ b/core/sequence.go
@@ -181,14 +181,14 @@ func (lc *LoadedContext) Timeline() []TimelineEntry {
 			"%s %s %s %d",
 			p.TimeString(),
 			p.PresetName,
-			p.Transition.String(),
+			p.TransitionString(),
 			p.Steps,
 		)
 
 		timeline = append(timeline, TimelineEntry{
 			Timestamp:  p.TimeString(),
 			PresetName: p.PresetName,
-			Transition: p.Transition.String(),
+			Transition: p.TransitionString(),
 			Steps:      p.Steps,
 			Line:       line,
 		})

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -199,6 +199,8 @@ So:
 - `ease-out` moves early and settles gently near the end;
 - `smooth` is gentle at both ends and more active around the middle.
 
+Custom transitions use `@transition name 0 ... 100` to provide an evenly sampled curve instead of a built-in shape. They apply to compatible parameter interpolation and fades involving `silence`. Automatic boundary crossfades for incompatible track types, effects, or sources remain linear. When a transition has steps, the custom curve is reapplied to every alternating leg.
+
 ### `steady`
 
 `steady` is the most neutral curve.

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -108,6 +108,7 @@ The currently supported `.spsq` options are:
 - `@music <name> <path-or-url>`
 - `@music <name>` as shorthand, where the path defaults to the same name
 - `@waveform <name> <point1> <point2> ... <pointN>`
+- `@transition <name> <point1> <point2> ... <pointN>`
 - `@extends <path-or-url>`
 
 Options must appear before presets or timeline entries. Once the builder has seen a preset, track, override, or timeline line, options are locked.
@@ -157,6 +158,27 @@ Rules:
 - an unknown `waveform <name>` reference is an error.
 
 The four built-ins retain their existing formulas and rendering behavior. Custom waveforms use the same track-level `waveform <name>` syntax and the same runtime wavetable path after name resolution. Sharp corners and steep segments can produce strong harmonics and aliasing; custom tables are not band-limited.
+
+### Custom Transitions
+
+A custom transition defines an evenly spaced interpolation curve for timeline changes:
+
+```spsq
+@transition soft-land 0 2 12 42 78 96 100
+
+00:00:00 silence soft-land
+00:00:30 focus
+```
+
+Rules:
+
+- names follow normal SPSQ name rules, are case-sensitive when referenced, and must not be `steady`, `ease-in`, `ease-out`, or `smooth`, including case variants;
+- a definition requires 2 through 256 decimal points from `0` through `100` in non-decreasing order;
+- the first point must be `0` and the last `100`;
+- definitions must be unique across the `.spsq` and all extended `.spsc` files;
+- a timeline transition name must be built-in or have a matching definition.
+
+Points are normalized to `0..1`, evenly distributed over the period, and linearly interpolated between adjacent points. The same curve is reapplied to each forward or backward leg created by `steps`. Custom curves govern compatible interpolation and fades to or from `silence`; automatic crossfades for incompatible channels remain linear.
 
 ## Presets
 
@@ -631,8 +653,9 @@ comment-line         = [indent] "#" text
 option-line          = "@samplerate" integer
                      | "@volume" integer
                      | "@ambiance" name [path-or-url]
-                     | "@music" name [path-or-url]
-                     | "@waveform" name waveform-point waveform-point { waveform-point }
+                      | "@music" name [path-or-url]
+                      | "@waveform" name waveform-point waveform-point { waveform-point }
+		      | "@transition" name transition-point transition-point { transition-point }
                      | "@extends" path-or-url ;
 
 preset-line          = name
@@ -667,6 +690,7 @@ music-tail           = "amplitude" amplitude-value
 waveform-prefix      = "waveform" waveform ;
 waveform             = name ;
 waveform-point       = float ;  (* 0 through 100; 2 through 16384 points *)
+transition-point     = float ;  (* non-decreasing 0 through 100; 2 through 256 points; first 0, last 100 *)
 amplitude-value      = float | "left" float "right" float ;  (* each 0 through 100 *)
 beat-kind            = "binaural" | "monaural" | "isochronic" ;
 noise-kind           = "white" | "pink" | "brown" ;
@@ -694,7 +718,8 @@ override-value       = signed-float | waveform ;
 
 timeline-line        = time name [transition [steps]] ;
 time                 = HH ":" MM ":" SS ;
-transition           = "steady" | "ease-in" | "ease-out" | "smooth" ;
+transition           = builtin-transition | name ;
+builtin-transition   = "steady" | "ease-in" | "ease-out" | "smooth" ;
 steps                = integer ;
 
 indent2              = exactly two leading spaces ;

--- a/internal/audio/renderer.go
+++ b/internal/audio/renderer.go
@@ -50,6 +50,7 @@ type AudioRendererOptions struct {
 	StatusOutput io.Writer
 	Colors       bool
 	Waveforms    []t.WaveformDefinition
+	Transitions  []t.TransitionDefinition
 }
 
 // NewAudioRenderer creates a new AudioRenderer instance
@@ -95,7 +96,7 @@ func NewAudioRenderer(p []t.Period, ar *AudioRendererOptions) (*AudioRenderer, e
 	}
 
 	renderer := &AudioRenderer{
-		plan:                 compileRenderPlanWithWaveforms(p, ar.SampleRate, waveforms),
+		plan:                 compileRenderPlanWithWaveformsAndTransitions(p, ar.SampleRate, waveforms, ar.Transitions),
 		periods:              p,
 		waveTables:           waveforms.Tables,
 		noiseGenerator:       NewNoiseGenerator(),

--- a/internal/audio/renderplan.go
+++ b/internal/audio/renderplan.go
@@ -23,6 +23,7 @@ type renderPlan struct {
 	sampleRate  int
 	totalFrames int64
 	waveforms   []periodWaveforms
+	transitions map[string][]float64
 }
 
 type periodWaveforms struct {
@@ -40,16 +41,25 @@ type renderWindow struct {
 
 func compileRenderPlan(periods []t.Period, sampleRate int) renderPlan {
 	waveforms, _ := wt.Compile(nil)
-	return compileRenderPlanWithWaveforms(periods, sampleRate, waveforms)
+	return compileRenderPlanWithWaveformsAndTransitions(periods, sampleRate, waveforms, nil)
 }
 
 func compileRenderPlanWithWaveforms(periods []t.Period, sampleRate int, registry *wt.Registry) renderPlan {
+	return compileRenderPlanWithWaveformsAndTransitions(periods, sampleRate, registry, nil)
+}
+
+func compileRenderPlanWithWaveformsAndTransitions(periods []t.Period, sampleRate int, registry *wt.Registry, definitions []t.TransitionDefinition) renderPlan {
+	transitions := make(map[string][]float64, len(definitions))
+	for _, definition := range definitions {
+		transitions[definition.Name] = definition.Points
+	}
 	plan := renderPlan{
 		periods:     periods,
 		windows:     make([]renderWindow, len(periods)),
 		sampleRate:  sampleRate,
 		totalFrames: totalFramesFromDuration(durationMs(periods), sampleRate),
 		waveforms:   make([]periodWaveforms, len(periods)),
+		transitions: transitions,
 	}
 
 	for index := range periods {
@@ -85,7 +95,7 @@ func (rp renderPlan) periodIndexAt(currentTimeMs int, currentPeriodIdx int) int 
 func (rp renderPlan) cue(periodIdx int, currentTimeMs int) audiosync.Cue {
 	window := rp.windows[periodIdx]
 	period := rp.periods[periodIdx]
-	alpha := tl.StepAlpha(rp.interpolationProgress(window, currentTimeMs), period.Transition, period.Steps)
+	alpha := tl.StepAlphaWithPoints(rp.interpolationProgress(window, currentTimeMs), period.Transition, rp.transitions[period.TransitionName], period.Steps)
 	cue := audiosync.Cue{
 		PeriodIndex: window.PeriodIndex,
 		Channels:    [t.NumberOfChannels]audiosync.ChannelCue{},

--- a/internal/dump/json.go
+++ b/internal/dump/json.go
@@ -13,14 +13,20 @@ import (
 )
 
 type document struct {
-	Comments  []string        `json:"comments"`
-	Options   options         `json:"options"`
-	Waveforms []waveform      `json:"waveforms"`
-	Presets   []preset        `json:"presets"`
-	Timeline  []timelineEntry `json:"timeline"`
+	Comments    []string        `json:"comments"`
+	Options     options         `json:"options"`
+	Waveforms   []waveform      `json:"waveforms"`
+	Transitions []transition    `json:"transitions"`
+	Presets     []preset        `json:"presets"`
+	Timeline    []timelineEntry `json:"timeline"`
 }
 
 type waveform struct {
+	Name   string    `json:"name"`
+	Points []float64 `json:"points"`
+}
+
+type transition struct {
 	Name   string    `json:"name"`
 	Points []float64 `json:"points"`
 }
@@ -75,14 +81,27 @@ func JSON(sequence *t.Sequence) ([]byte, error) {
 	}
 
 	doc := document{
-		Comments:  sequenceComments(sequence),
-		Options:   sequenceOptions(sequence.Options),
-		Waveforms: sequenceWaveforms(sequence.Waveforms),
-		Presets:   sequencePresets(sequence.Presets),
-		Timeline:  sequenceTimeline(sequence.Periods),
+		Comments:    sequenceComments(sequence),
+		Options:     sequenceOptions(sequence.Options),
+		Waveforms:   sequenceWaveforms(sequence.Waveforms),
+		Transitions: sequenceTransitions(sequence.Transitions),
+		Presets:     sequencePresets(sequence.Presets),
+		Timeline:    sequenceTimeline(sequence.Periods),
 	}
 
 	return json.MarshalIndent(doc, "", "  ")
+}
+
+func sequenceTransitions(definitions []t.TransitionDefinition) []transition {
+	result := make([]transition, 0, len(definitions))
+	for _, definition := range definitions {
+		points := make([]float64, len(definition.Points))
+		for index, point := range definition.Points {
+			points[index] = point * 100
+		}
+		result = append(result, transition{Name: definition.Name, Points: points})
+	}
+	return result
 }
 
 func sequenceWaveforms(definitions []t.WaveformDefinition) []waveform {
@@ -207,14 +226,14 @@ func sequenceTimeline(periods []t.Period) []timelineEntry {
 			"%s %s %s %d",
 			periods[i].TimeString(),
 			periods[i].PresetName,
-			periods[i].Transition.String(),
+			periods[i].TransitionString(),
 			periods[i].Steps,
 		)
 
 		result = append(result, timelineEntry{
 			Timestamp:  periods[i].TimeString(),
 			PresetName: periods[i].PresetName,
-			Transition: periods[i].Transition.String(),
+			Transition: periods[i].TransitionString(),
 			Steps:      periods[i].Steps,
 			Line:       line,
 		})

--- a/internal/dump/json_test.go
+++ b/internal/dump/json_test.go
@@ -58,8 +58,9 @@ func TestJSONSerializesLoadedSequence(ts *testing.T) {
 	}
 
 	seq := &t.Sequence{
-		Comments:  []string{},
-		Waveforms: []t.WaveformDefinition{{Name: "pulse", Points: []float64{-1, 0, 1}}},
+		Comments:    []string{},
+		Waveforms:   []t.WaveformDefinition{{Name: "pulse", Points: []float64{-1, 0, 1}}},
+		Transitions: []t.TransitionDefinition{{Name: "soft-land", Points: []float64{0, 0.2, 1}}},
 		Options: &t.SequenceOptions{
 			SampleRate: 44100,
 			Volume:     100,
@@ -69,7 +70,7 @@ func TestJSONSerializesLoadedSequence(ts *testing.T) {
 		},
 		Presets: []t.Preset{*t.NewBuiltinSilencePreset(), *alpha},
 		Periods: []t.Period{
-			{Time: 0, PresetName: "alpha", Transition: t.TransitionSteady},
+			{Time: 0, PresetName: "alpha", Transition: t.TransitionSteady, TransitionName: "soft-land"},
 		},
 	}
 
@@ -105,6 +106,14 @@ func TestJSONSerializesLoadedSequence(ts *testing.T) {
 	if waveform["name"] != "pulse" || points[0] != float64(0) || points[1] != float64(50) || points[2] != float64(100) {
 		ts.Fatalf("unexpected custom waveform JSON: %#v", waveform)
 	}
+	transitions := got["transitions"].([]any)
+	if len(transitions) != 1 {
+		ts.Fatalf("expected one custom transition, got %d", len(transitions))
+	}
+	transition := transitions[0].(map[string]any)
+	if transition["name"] != "soft-land" || !slices.Equal(transition["points"].([]any), []any{float64(0), float64(20), float64(100)}) {
+		ts.Fatalf("unexpected custom transition JSON: %#v", transition)
+	}
 
 	presets := got["presets"].([]any)
 	if len(presets) != 1 {
@@ -138,7 +147,7 @@ func TestJSONSerializesLoadedSequence(ts *testing.T) {
 
 	timeline := got["timeline"].([]any)
 	entry := timeline[0].(map[string]any)
-	if entry["presetName"] != "alpha" || entry["timestamp"] != "00:00:00" {
+	if entry["presetName"] != "alpha" || entry["timestamp"] != "00:00:00" || entry["transition"] != "soft-land" {
 		ts.Fatalf("unexpected timeline entry: %#v", entry)
 	}
 

--- a/internal/parser/option.go
+++ b/internal/parser/option.go
@@ -48,6 +48,7 @@ func (ctx *TextParser) ParseOption(_ string) (*t.ParseOptions, error) {
 		t.KeywordOptionMusic,
 		t.KeywordOptionExtends,
 		t.KeywordOptionWaveform,
+		t.KeywordOptionTransition,
 	}
 
 	switch option {
@@ -145,6 +146,48 @@ func (ctx *TextParser) ParseOption(_ string) (*t.ParseOptions, error) {
 			Name:   t.WaveformName(name),
 			Points: points,
 		})
+	case t.KeywordOptionTransition:
+		name, ok := ctx.Line.NextToken()
+		if !ok {
+			return nil, diag.UnexpectedEOF(ctx.Line.EOFSpan(), "transition name")
+		}
+		nameSpan, _ := ctx.Line.LastTokenSpan()
+		if err := nr.IsValid(name); err != nil {
+			return nil, diag.Validation(err.Error()).WithSpan(nameSpan).WithFound(name).WithCause(err)
+		}
+		if t.IsBuiltinTransitionName(name) {
+			return nil, diag.Validation(fmt.Sprintf("transition name %q is reserved for a built-in transition", name)).WithSpan(nameSpan).WithFound(name)
+		}
+
+		points := make([]float64, 0)
+		for {
+			_, ok := ctx.Line.Peek()
+			if !ok {
+				break
+			}
+			value, err := ctx.Line.NextFloat64Strict()
+			if err != nil {
+				return nil, err
+			}
+			valueSpan, _ := ctx.Line.LastTokenSpan()
+			if value < 0 || value > 100 {
+				return nil, diag.Validation("transition points must be between 0 and 100").WithSpan(valueSpan).WithFound(fmt.Sprintf("%g", value))
+			}
+			if len(points) == t.MaxTransitionPoints {
+				return nil, diag.Validation(fmt.Sprintf("transition cannot contain more than %d points", t.MaxTransitionPoints)).WithSpan(valueSpan)
+			}
+			if len(points) > 0 && value < points[len(points)-1]*100 {
+				return nil, diag.Validation("transition points must be monotonic").WithSpan(valueSpan).WithFound(fmt.Sprintf("%g", value))
+			}
+			points = append(points, value/100)
+		}
+		if len(points) < t.MinTransitionPoints {
+			return nil, diag.Validation(fmt.Sprintf("transition must contain at least %d points", t.MinTransitionPoints)).WithSpan(nameSpan).WithFound(name)
+		}
+		if points[0] != 0 || points[len(points)-1] != 1 {
+			return nil, diag.Validation("transition must start at 0 and end at 100").WithSpan(nameSpan).WithFound(name)
+		}
+		parsed.Transitions = append(parsed.Transitions, t.TransitionDefinition{Name: name, Points: points})
 	default:
 		diagnostic := diag.Parse("invalid option").WithSpan(span).WithFound(option).WithExpected(validOptions...)
 		if suggestion, ok := diag.ClosestMatch(option, validOptions, diag.DefaultSuggestionDistance(option)); ok {

--- a/internal/parser/option_test.go
+++ b/internal/parser/option_test.go
@@ -77,6 +77,20 @@ func TestParseOption(ts *testing.T) {
 				}},
 			},
 		},
+		{
+			"@transition soft-land 0 20 50 100",
+			&t.ParseOptions{
+				Values:    map[string]string{},
+				Ambiance:  map[string]string{},
+				Music:     map[string]string{},
+				Extends:   []string{},
+				Waveforms: []t.WaveformDefinition{},
+				Transitions: []t.TransitionDefinition{{
+					Name:   "soft-land",
+					Points: []float64{0, 0.2, 0.5, 1},
+				}},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -107,6 +121,9 @@ func TestParseOptionErrors(ts *testing.T) {
 			wantErrText: "unexpected token after option definition",
 		},
 		{name: "missing waveform name", line: "@waveform", wantErrText: "waveform name"},
+		{name: "transition requires endpoints", line: "@transition soft 0 80", wantErrText: "transition must start at 0 and end at 100"},
+		{name: "transition points are monotonic", line: "@transition soft 0 80 70 100", wantErrText: "transition points must be monotonic"},
+		{name: "transition name is reserved", line: "@transition smooth 0 100", wantErrText: "reserved for a built-in transition"},
 		{name: "empty waveform", line: "@waveform pulse", wantErrText: "at least 2 points"},
 		{name: "one waveform point", line: "@waveform pulse 50", wantErrText: "at least 2 points"},
 		{name: "non-numeric waveform point", line: "@waveform pulse 0 nope", wantErrText: "invalid float"},

--- a/internal/parser/timeline.go
+++ b/internal/parser/timeline.go
@@ -10,14 +10,16 @@ import (
 	"strings"
 
 	"github.com/synapseq-foundation/synapseq/v4/internal/diag"
+	nr "github.com/synapseq-foundation/synapseq/v4/internal/nameref"
 	t "github.com/synapseq-foundation/synapseq/v4/internal/types"
 )
 
 type ParsedTimelineDeclaration struct {
-	Time       int
-	PresetName string
-	Transition t.TransitionType
-	Steps      int
+	Time           int
+	PresetName     string
+	Transition     t.TransitionType
+	TransitionName string
+	Steps          int
 }
 
 // parseTime parses a time string in HH:MM:SS format to milliseconds
@@ -107,7 +109,10 @@ func (ctx *TextParser) ParseTimelineDeclaration() (*ParsedTimelineDeclaration, e
 		case t.KeywordTransitionSmooth:
 			decl.Transition = t.TransitionSmooth
 		default:
-			return nil, diag.UnexpectedToken(transitionSpan, transition, t.KeywordTransitionSteady, t.KeywordTransitionEaseOut, t.KeywordTransitionEaseIn, t.KeywordTransitionSmooth)
+			if err := nr.IsValid(transition); err != nil {
+				return nil, diag.Validation(err.Error()).WithSpan(transitionSpan).WithFound(transition).WithCause(err)
+			}
+			decl.TransitionName = transition
 		}
 
 		if stepToken, ok := ctx.Line.Peek(); ok {

--- a/internal/parser/timeline_test.go
+++ b/internal/parser/timeline_test.go
@@ -37,32 +37,31 @@ func TestHasTimeline(ts *testing.T) {
 
 func TestParseTimelineDeclaration(ts *testing.T) {
 	tests := []struct {
-		line               string
-		expectError        bool
-		expectedMs         int
-		expectedPreset     string
-		expectedTransition t.TransitionType
-		expectedSteps      int
+		line                   string
+		expectError            bool
+		expectedMs             int
+		expectedPreset         string
+		expectedTransition     t.TransitionType
+		expectedTransitionName string
+		expectedSteps          int
 	}{
-		{"00:00:00 alpha", false, 0, "alpha", t.TransitionSteady, 0},
-		{"00:00:15 alpha", false, 15_000, "alpha", t.TransitionSteady, 0},
-		{"12:34:56 alpha", false, (12*3600 + 34*60 + 56) * 1000, "alpha", t.TransitionSteady, 0},
-		{"00:01:00 alpha ease-out", false, 60_000, "alpha", t.TransitionEaseOut, 0},
-		{"00:02:00 alpha ease-in", false, 120_000, "alpha", t.TransitionEaseIn, 0},
-		{"00:03:00 alpha smooth", false, 180_000, "alpha", t.TransitionSmooth, 0},
-		{"00:03:00 alpha smooth 3", false, 180_000, "alpha", t.TransitionSmooth, 3},
-		{"00:03:00 alpha steady 0", false, 180_000, "alpha", t.TransitionSteady, 0},
-		{"24:00:00 alpha", true, 0, "", t.TransitionSteady, 0},
-		{"00:60:00 alpha", true, 0, "", t.TransitionSteady, 0},
-		{"00:00:60 alpha", true, 0, "", t.TransitionSteady, 0},
-		{"00:00:05 alpha extra", true, 0, "", t.TransitionSteady, 0},
-		{"00:00:05", true, 0, "", t.TransitionSteady, 0},
-		{"00:00 alpha", true, 0, "", t.TransitionSteady, 0},
-		{"00:00:05 alpha invalid-transition", true, 0, "", t.TransitionSteady, 0},
-		{"00:00:05 alpha steady -1", true, 0, "", t.TransitionSteady, 0},
-		{"00:00:05 alpha 4", true, 0, "", t.TransitionSteady, 0},
-		{"00:00:05 alpha steady extra", true, 0, "", t.TransitionSteady, 0},
-		{"00:00:05 alpha steady 3 extra", true, 0, "", t.TransitionSteady, 0},
+		{"00:00:00 alpha", false, 0, "alpha", t.TransitionSteady, "", 0},
+		{"00:00:15 alpha", false, 15_000, "alpha", t.TransitionSteady, "", 0},
+		{"12:34:56 alpha", false, (12*3600 + 34*60 + 56) * 1000, "alpha", t.TransitionSteady, "", 0},
+		{"00:01:00 alpha ease-out", false, 60_000, "alpha", t.TransitionEaseOut, "", 0},
+		{"00:02:00 alpha ease-in", false, 120_000, "alpha", t.TransitionEaseIn, "", 0},
+		{"00:03:00 alpha smooth", false, 180_000, "alpha", t.TransitionSmooth, "", 0},
+		{"00:03:00 alpha soft-land 3", false, 180_000, "alpha", t.TransitionSteady, "soft-land", 3},
+		{"00:03:00 alpha steady 0", false, 180_000, "alpha", t.TransitionSteady, "", 0},
+		{"24:00:00 alpha", true, 0, "", t.TransitionSteady, "", 0},
+		{"00:60:00 alpha", true, 0, "", t.TransitionSteady, "", 0},
+		{"00:00:60 alpha", true, 0, "", t.TransitionSteady, "", 0},
+		{"00:00:05", true, 0, "", t.TransitionSteady, "", 0},
+		{"00:00 alpha", true, 0, "", t.TransitionSteady, "", 0},
+		{"00:00:05 alpha steady -1", true, 0, "", t.TransitionSteady, "", 0},
+		{"00:00:05 alpha 4", true, 0, "", t.TransitionSteady, "", 0},
+		{"00:00:05 alpha steady extra", true, 0, "", t.TransitionSteady, "", 0},
+		{"00:00:05 alpha steady 3 extra", true, 0, "", t.TransitionSteady, "", 0},
 	}
 
 	for _, test := range tests {
@@ -86,6 +85,9 @@ func TestParseTimelineDeclaration(ts *testing.T) {
 		}
 		if decl.Transition != test.expectedTransition {
 			ts.Errorf("For line '%s', expected transition %v but got %v", test.line, test.expectedTransition, decl.Transition)
+		}
+		if decl.TransitionName != test.expectedTransitionName {
+			ts.Errorf("For line '%s', expected transition name %q but got %q", test.line, test.expectedTransitionName, decl.TransitionName)
 		}
 		if decl.Steps != test.expectedSteps {
 			ts.Errorf("For line '%s', expected steps %d but got %d", test.line, test.expectedSteps, decl.Steps)
@@ -140,7 +142,7 @@ func TestParseTime(ts *testing.T) {
 }
 
 func TestParseTimelineTransitionDiagnostic(ts *testing.T) {
-	ctx := NewTextParser("00:00:05 alpha smooh")
+	ctx := NewTextParser("00:00:05 alpha invalid.transition")
 	_, err := ctx.ParseTimelineDeclaration()
 	if err == nil {
 		ts.Fatal("expected transition diagnostic")
@@ -150,14 +152,11 @@ func TestParseTimelineTransitionDiagnostic(ts *testing.T) {
 	if !ok {
 		ts.Fatalf("expected diag.Diagnostic, got %T", err)
 	}
-	if diagnostic.Found != "smooh" {
-		ts.Fatalf("expected found transition smooh, got %q", diagnostic.Found)
+	if diagnostic.Found != "invalid.transition" {
+		ts.Fatalf("expected found transition invalid.transition, got %q", diagnostic.Found)
 	}
-	if diagnostic.Suggestion != "did you mean \"smooth\"?" {
-		ts.Fatalf("expected smooth suggestion, got %q", diagnostic.Suggestion)
-	}
-	if diagnostic.Span.Column != 16 || diagnostic.Span.EndColumn != 21 {
-		ts.Fatalf("expected transition span 17..22, got %d..%d", diagnostic.Span.Column, diagnostic.Span.EndColumn)
+	if diagnostic.Span.Column != 16 || diagnostic.Span.EndColumn != 34 {
+		ts.Fatalf("expected transition span 16..34, got %d..%d", diagnostic.Span.Column, diagnostic.Span.EndColumn)
 	}
 }
 

--- a/internal/sequence/builder.go
+++ b/internal/sequence/builder.go
@@ -169,7 +169,7 @@ func (b *sequenceBuilder) handleTimeline(lineNumber int, lineText string, ctx *p
 		return withSource(err, b.sourceFile, lineNumber, lineText)
 	}
 
-	period, err := buildPeriodFromDeclaration(b.sourceFile, lineNumber, lineText, decl, b.presets)
+	period, err := buildPeriodFromDeclaration(b.sourceFile, lineNumber, lineText, decl, b.presets, b.rawOptions.Transitions)
 	if err != nil {
 		return err
 	}

--- a/internal/sequence/loadtext_test.go
+++ b/internal/sequence/loadtext_test.go
@@ -459,6 +459,49 @@ beta
 	}
 }
 
+func TestLoadTextSequence_CustomTransition(ts *testing.T) {
+	seq := `
+@transition soft-land 0 20 50 100
+
+alpha
+  tone 200 amplitude 10
+
+beta
+  tone 210 amplitude 10
+
+00:00:00 alpha
+00:00:01 beta soft-land 3
+`
+	result, err := loadTextSequenceFile(ts, writeSeqFile(ts, seq))
+	if err != nil {
+		ts.Fatalf("LoadTextSequence error: %v", err)
+	}
+	if len(result.Transitions) != 1 || result.Transitions[0].Name != "soft-land" {
+		ts.Fatalf("unexpected transition definitions: %+v", result.Transitions)
+	}
+	period := result.Periods[1]
+	if period.TransitionName != "soft-land" || period.Steps != 3 {
+		ts.Fatalf("unexpected custom transition period: %+v", period)
+	}
+}
+
+func TestLoadTextSequence_RejectsUnknownTransition(ts *testing.T) {
+	seq := `
+alpha
+  tone 200 amplitude 10
+
+beta
+  tone 210 amplitude 10
+
+00:00:00 alpha
+00:00:01 beta missing
+`
+	_, err := loadTextSequenceFile(ts, writeSeqFile(ts, seq))
+	if err == nil || !strings.Contains(err.Error(), `unknown transition "missing"`) {
+		ts.Fatalf("expected unknown transition error, got %v", err)
+	}
+}
+
 func TestLoadTextSequence_CustomWaveformOverride(ts *testing.T) {
 	seq := `
 @waveform pulse 0 100

--- a/internal/sequence/presetresolve.go
+++ b/internal/sequence/presetresolve.go
@@ -37,7 +37,7 @@ func buildPresetFromDeclaration(sourceFile string, lineNumber int, lineText stri
 	return preset, nil
 }
 
-func buildPeriodFromDeclaration(sourceFile string, lineNumber int, lineText string, decl *parser.ParsedTimelineDeclaration, presets []t.Preset) (*t.Period, error) {
+func buildPeriodFromDeclaration(sourceFile string, lineNumber int, lineText string, decl *parser.ParsedTimelineDeclaration, presets []t.Preset, transitions []t.TransitionDefinition) (*t.Period, error) {
 	selectedPreset := p.FindPreset(strings.ToLower(decl.PresetName), presets)
 	if selectedPreset == nil {
 		return nil, lineDiagnostic(sourceFile, lineNumber, lineText, fmt.Sprintf("preset %q not found", decl.PresetName))
@@ -45,13 +45,17 @@ func buildPeriodFromDeclaration(sourceFile string, lineNumber int, lineText stri
 	if selectedPreset.IsTemplate {
 		return nil, lineDiagnostic(sourceFile, lineNumber, lineText, fmt.Sprintf("cannot use template preset %q in timeline", selectedPreset.String()))
 	}
+	if err := validateTransitionReference(decl.TransitionName, transitions); err != nil {
+		return nil, lineDiagnostic(sourceFile, lineNumber, lineText, err.Error())
+	}
 
 	return &t.Period{
-		Time:       decl.Time,
-		PresetName: selectedPreset.String(),
-		TrackStart: selectedPreset.Track,
-		TrackEnd:   selectedPreset.Track,
-		Transition: decl.Transition,
-		Steps:      decl.Steps,
+		Time:           decl.Time,
+		PresetName:     selectedPreset.String(),
+		TrackStart:     selectedPreset.Track,
+		TrackEnd:       selectedPreset.Track,
+		Transition:     decl.Transition,
+		TransitionName: decl.TransitionName,
+		Steps:          decl.Steps,
 	}, nil
 }

--- a/internal/sequence/validation.go
+++ b/internal/sequence/validation.go
@@ -26,6 +26,9 @@ func mergeSequenceExtends(sourceFile string, lineNumber int, lineText string, pa
 	if err := validateWaveformDefinitions(sourceFile, lineNumber, lineText, rawOptions.Waveforms, parsedOptions.Waveforms); err != nil {
 		return err
 	}
+	if err := validateTransitionDefinitions(sourceFile, lineNumber, lineText, rawOptions.Transitions, parsedOptions.Transitions); err != nil {
+		return err
+	}
 	rawOptions.Merge(parsedOptions)
 
 	for _, extFile := range parsedOptions.Extends {
@@ -40,6 +43,9 @@ func mergeSequenceExtends(sourceFile string, lineNumber int, lineText string, pa
 
 		loadedExtends[extFile] = struct{}{}
 		if err := validateWaveformDefinitions(sourceFile, lineNumber, lineText, rawOptions.Waveforms, extendsConfig.Options.Waveforms); err != nil {
+			return err
+		}
+		if err := validateTransitionDefinitions(sourceFile, lineNumber, lineText, rawOptions.Transitions, extendsConfig.Options.Transitions); err != nil {
 			return err
 		}
 		*presets = append(*presets, extendsConfig.Presets...)
@@ -194,12 +200,13 @@ func finalizeSequence(rawContent []byte, presets []t.Preset, periods []t.Period,
 	}
 
 	return &t.Sequence{
-		Periods:    periods,
-		Presets:    presets,
-		Options:    options,
-		Waveforms:  append([]t.WaveformDefinition{}, rawOptions.Waveforms...),
-		Comments:   comments,
-		RawContent: rawContent,
+		Periods:     periods,
+		Presets:     presets,
+		Options:     options,
+		Waveforms:   append([]t.WaveformDefinition{}, rawOptions.Waveforms...),
+		Transitions: append([]t.TransitionDefinition{}, rawOptions.Transitions...),
+		Comments:    comments,
+		RawContent:  rawContent,
 	}, nil
 }
 
@@ -219,12 +226,41 @@ func validateExtendsOptionContent(sourceFile string, lineNumber int, lineText st
 	if err := validateWaveformDefinitions(sourceFile, lineNumber, lineText, rawOptions.Waveforms, parsedOptions.Waveforms); err != nil {
 		return err
 	}
+	if err := validateTransitionDefinitions(sourceFile, lineNumber, lineText, rawOptions.Transitions, parsedOptions.Transitions); err != nil {
+		return err
+	}
 	rawOptions.Merge(parsedOptions)
 	if _, err := rawOptions.Build(); err != nil {
 		return withSource(err, sourceFile, lineNumber, lineText)
 	}
 
 	return nil
+}
+
+func validateTransitionDefinitions(sourceFile string, lineNumber int, lineText string, existing []t.TransitionDefinition, incoming []t.TransitionDefinition) error {
+	names := make([]string, 0, len(existing)+len(incoming))
+	for _, definition := range existing {
+		names = append(names, definition.Name)
+	}
+	for _, definition := range incoming {
+		if slices.Contains(names, definition.Name) {
+			return lineDiagnostic(sourceFile, lineNumber, lineText, fmt.Sprintf("duplicate transition definition: %s", definition.Name))
+		}
+		names = append(names, definition.Name)
+	}
+	return nil
+}
+
+func validateTransitionReference(name string, definitions []t.TransitionDefinition) error {
+	if name == "" {
+		return nil
+	}
+	for _, definition := range definitions {
+		if definition.Name == name {
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown transition %q", name)
 }
 
 func validateWaveformDefinitions(

--- a/internal/timeline/transition.go
+++ b/internal/timeline/transition.go
@@ -64,14 +64,43 @@ func ApplyTransitionAlpha(progress float64, transition t.TransitionType) float64
 	return alpha
 }
 
+// ApplyTransitionPoints maps progress through uniformly distributed custom curve points.
+func ApplyTransitionPoints(progress float64, points []float64) float64 {
+	if len(points) == 0 {
+		return clampUnit(progress)
+	}
+
+	progress = clampUnit(progress)
+	if progress >= 1 {
+		return points[len(points)-1]
+	}
+
+	span := 1.0 / float64(len(points)-1)
+	index := int(math.Floor(progress / span))
+	if index >= len(points)-1 {
+		return points[len(points)-1]
+	}
+
+	local := (progress - float64(index)*span) / span
+	return points[index] + (points[index+1]-points[index])*local
+}
+
 // StepAlpha computes the effective interpolation alpha for a period.
 //
 // Steps=0 preserves the current monotonic transition. Steps>0 creates an
 // alternating trajectory with 2*steps+1 legs so the period always starts at
 // TrackStart and ends exactly at TrackEnd.
 func StepAlpha(progress float64, transition t.TransitionType, steps int) float64 {
+	return StepAlphaWithPoints(progress, transition, nil, steps)
+}
+
+// StepAlphaWithPoints computes alpha using either a built-in transition or custom curve points.
+func StepAlphaWithPoints(progress float64, transition t.TransitionType, points []float64, steps int) float64 {
 	progress = clampUnit(progress)
 	if steps <= 0 {
+		if len(points) > 0 {
+			return ApplyTransitionPoints(progress, points)
+		}
 		return ApplyTransitionAlpha(progress, transition)
 	}
 	if progress >= 1 {
@@ -88,6 +117,9 @@ func StepAlpha(progress float64, transition t.TransitionType, steps int) float64
 	legStart := float64(legIndex) * legSpan
 	legProgress := clampUnit((progress - legStart) / legSpan)
 	curved := ApplyTransitionAlpha(legProgress, transition)
+	if len(points) > 0 {
+		curved = ApplyTransitionPoints(legProgress, points)
+	}
 	if legIndex%2 == 0 {
 		return curved
 	}

--- a/internal/timeline/transition_test.go
+++ b/internal/timeline/transition_test.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 SynapSeq Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package timeline
+
+import (
+	"math"
+	"testing"
+)
+
+func TestApplyTransitionPoints(ts *testing.T) {
+	points := []float64{0, 0.2, 1}
+	for _, test := range []struct {
+		progress float64
+		want     float64
+	}{
+		{0, 0},
+		{0.25, 0.1},
+		{0.5, 0.2},
+		{0.75, 0.6},
+		{1, 1},
+	} {
+		if got := ApplyTransitionPoints(test.progress, points); math.Abs(got-test.want) > 1e-9 {
+			ts.Errorf("ApplyTransitionPoints(%v) = %v, want %v", test.progress, got, test.want)
+		}
+	}
+}
+
+func TestStepAlphaWithPointsReappliesCurvePerStep(ts *testing.T) {
+	points := []float64{0, 0.2, 1}
+	if got := StepAlphaWithPoints(0.75, 0, points, 2); math.Abs(got-0.4) > 1e-9 {
+		ts.Fatalf("StepAlphaWithPoints() = %v, want 0.4", got)
+	}
+}

--- a/internal/types/parser.go
+++ b/internal/types/parser.go
@@ -31,6 +31,8 @@ const (
 	KeywordOptionExtends = "extends"
 	// Represents a custom waveform option
 	KeywordOptionWaveform = "waveform"
+	// Represents a custom transition option
+	KeywordOptionTransition = "transition"
 	// Represents a waveform option
 	KeywordWaveform = "waveform"
 	// Represents a sine wave
@@ -101,11 +103,12 @@ const (
 
 // ParseOptions stores raw option values parsed from text input
 type ParseOptions struct {
-	Values    map[string]string
-	Ambiance  map[string]string
-	Music     map[string]string
-	Extends   []string
-	Waveforms []WaveformDefinition
+	Values      map[string]string
+	Ambiance    map[string]string
+	Music       map[string]string
+	Extends     []string
+	Waveforms   []WaveformDefinition
+	Transitions []TransitionDefinition
 }
 
 // NewParseOptions creates an empty ParseOptions instance
@@ -140,12 +143,16 @@ func (po *ParseOptions) Merge(other *ParseOptions) {
 	if po.Waveforms == nil {
 		po.Waveforms = []WaveformDefinition{}
 	}
+	if po.Transitions == nil {
+		po.Transitions = []TransitionDefinition{}
+	}
 
 	maps.Copy(po.Values, other.Values)
 	maps.Copy(po.Ambiance, other.Ambiance)
 	maps.Copy(po.Music, other.Music)
 	po.Extends = append(po.Extends, other.Extends...)
 	po.Waveforms = append(po.Waveforms, other.Waveforms...)
+	po.Transitions = append(po.Transitions, other.Transitions...)
 }
 
 // Build converts parsed raw options into validated SequenceOptions

--- a/internal/types/period.go
+++ b/internal/types/period.go
@@ -53,14 +53,23 @@ func TransitionTypeString(t string) TransitionType {
 
 // Period represents a time period with track configurations
 type Period struct {
-	Time         int
-	PresetName   string
-	TrackStart   [NumberOfChannels]Track
-	TrackEnd     [NumberOfChannels]Track
-	CrossfadeIn  [NumberOfChannels]TrackCrossfade
-	CrossfadeOut [NumberOfChannels]TrackCrossfade
-	Transition   TransitionType
-	Steps        int
+	Time           int
+	PresetName     string
+	TrackStart     [NumberOfChannels]Track
+	TrackEnd       [NumberOfChannels]Track
+	CrossfadeIn    [NumberOfChannels]TrackCrossfade
+	CrossfadeOut   [NumberOfChannels]TrackCrossfade
+	Transition     TransitionType
+	TransitionName string
+	Steps          int
+}
+
+// TransitionString returns the built-in or custom transition name.
+func (p *Period) TransitionString() string {
+	if p.TransitionName != "" {
+		return p.TransitionName
+	}
+	return p.Transition.String()
 }
 
 // TrackCrossfade describes an automatic boundary fade for a channel.

--- a/internal/types/sequence.go
+++ b/internal/types/sequence.go
@@ -8,12 +8,13 @@ import "fmt"
 
 // Sequence represents a brainwave sequence
 type Sequence struct {
-	Periods    []Period
-	Presets    []Preset
-	Options    *SequenceOptions
-	Waveforms  []WaveformDefinition
-	Comments   []string
-	RawContent []byte
+	Periods     []Period
+	Presets     []Preset
+	Options     *SequenceOptions
+	Waveforms   []WaveformDefinition
+	Transitions []TransitionDefinition
+	Comments    []string
+	RawContent  []byte
 }
 
 // SequenceOptions represents configuration options for a sequence

--- a/internal/types/transition.go
+++ b/internal/types/transition.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2026 SynapSeq Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package types
+
+import "strings"
+
+const (
+	MinTransitionPoints = 2
+	MaxTransitionPoints = 256
+)
+
+// TransitionDefinition contains one normalized monotonic interpolation curve.
+type TransitionDefinition struct {
+	Name   string
+	Points []float64
+}
+
+// IsBuiltinTransitionName reports whether name conflicts with a built-in transition.
+func IsBuiltinTransitionName(name string) bool {
+	switch strings.ToLower(name) {
+	case KeywordTransitionSteady, KeywordTransitionEaseOut, KeywordTransitionEaseIn, KeywordTransitionSmooth:
+		return true
+	default:
+		return false
+	}
+}
+
+// BuiltinTransitionNames returns the transition names accepted without a definition.
+func BuiltinTransitionNames() []string {
+	return []string{KeywordTransitionSteady, KeywordTransitionEaseOut, KeywordTransitionEaseIn, KeywordTransitionSmooth}
+}

--- a/spsq/builder.go
+++ b/spsq/builder.go
@@ -15,13 +15,14 @@ import (
 
 // Builder is responsible for building a sequence from a string sequence content
 type Builder struct {
-	ctx       *synapseq.AppContext
-	timeline  []timelineEntry
-	ambiance  []ambianceOption
-	music     []musicOption
-	waveforms []waveformOption
-	options   map[string]string
-	presets   []presetEntry
+	ctx         *synapseq.AppContext
+	timeline    []timelineEntry
+	ambiance    []ambianceOption
+	music       []musicOption
+	waveforms   []waveformOption
+	transitions []transitionOption
+	options     map[string]string
+	presets     []presetEntry
 }
 
 // ambianceOption holds the name and path of an ambiance source
@@ -38,6 +39,11 @@ type musicOption struct {
 
 // waveformOption holds one custom waveform definition.
 type waveformOption struct {
+	name   string
+	points []float64
+}
+
+type transitionOption struct {
 	name   string
 	points []float64
 }
@@ -63,13 +69,14 @@ func New(ctx *synapseq.AppContext) (*Builder, error) {
 	}
 
 	return &Builder{
-		ctx:       ctx,
-		timeline:  make([]timelineEntry, 0),
-		ambiance:  make([]ambianceOption, 0),
-		music:     make([]musicOption, 0),
-		waveforms: make([]waveformOption, 0),
-		options:   make(map[string]string),
-		presets:   make([]presetEntry, 0),
+		ctx:         ctx,
+		timeline:    make([]timelineEntry, 0),
+		ambiance:    make([]ambianceOption, 0),
+		music:       make([]musicOption, 0),
+		waveforms:   make([]waveformOption, 0),
+		transitions: make([]transitionOption, 0),
+		options:     make(map[string]string),
+		presets:     make([]presetEntry, 0),
 	}, nil
 }
 
@@ -97,6 +104,13 @@ func (b *Builder) content() string {
 	for _, waveform := range b.waveforms {
 		fmt.Fprintf(&content, "%s%s %s", opt, t.KeywordOptionWaveform, waveform.name)
 		for _, point := range waveform.points {
+			fmt.Fprintf(&content, " %s", formatWaveformPoint(point))
+		}
+		content.WriteByte('\n')
+	}
+	for _, transition := range b.transitions {
+		fmt.Fprintf(&content, "%s%s %s", opt, t.KeywordOptionTransition, transition.name)
+		for _, point := range transition.points {
 			fmt.Fprintf(&content, " %s", formatWaveformPoint(point))
 		}
 		content.WriteByte('\n')

--- a/spsq/builder_test.go
+++ b/spsq/builder_test.go
@@ -124,6 +124,33 @@ func TestBuilderCustomWaveform(t *testing.T) {
 	}
 }
 
+func TestBuilderCustomTransition(t *testing.T) {
+	builder, err := New(synapseq.NewAppContext())
+	if err != nil {
+		t.Fatalf("New error: %v", err)
+	}
+	builder.Transition("soft-land", 0, 20, 50, 100)
+
+	focus := builder.NewPreset("focus")
+	focus.Tone(200).Amplitude(20)
+
+	loaded, err := builder.
+		PresetAt(0, focus).UseTransition("soft-land").
+		PresetAt(time.Second, focus).
+		Load()
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+
+	content := string(loaded.RawContent())
+	if !strings.Contains(content, "@transition soft-land 0 20 50 100") {
+		t.Fatalf("missing custom transition declaration:\n%s", content)
+	}
+	if !strings.Contains(content, "00:00:00 focus soft-land 0") {
+		t.Fatalf("missing custom transition reference:\n%s", content)
+	}
+}
+
 func TestBuilderCustomWaveformValidationErrors(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/spsq/option.go
+++ b/spsq/option.go
@@ -43,6 +43,15 @@ func (b *Builder) Waveform(name string, points ...float64) *Builder {
 	return b
 }
 
+// Transition registers a custom timeline transition for the sequence.
+func (b *Builder) Transition(name string, points ...float64) *Builder {
+	b.transitions = append(b.transitions, transitionOption{
+		name:   name,
+		points: append([]float64{}, points...),
+	})
+	return b
+}
+
 func formatWaveformPoint(point float64) string {
 	return strconv.FormatFloat(point, 'f', -1, 64)
 }

--- a/spsq/timeline.go
+++ b/spsq/timeline.go
@@ -81,6 +81,16 @@ func (b *Builder) Smooth() *Builder {
 	return b
 }
 
+// UseTransition sets the transition of the last timeline entry by custom name.
+func (b *Builder) UseTransition(name string) *Builder {
+	if len(b.timeline) == 0 {
+		return b
+	}
+
+	b.timeline[len(b.timeline)-1].transition = name
+	return b
+}
+
 // Step sets the step count of the last timeline entry.
 func (b *Builder) Step(s int) *Builder {
 	if len(b.timeline) == 0 {


### PR DESCRIPTION
## Summary
- add named custom transition curves with parser, validation, inheritance, rendering, JSON dump, and Go builder support
- apply custom curves to compatible interpolation, silence fades, and every steps leg while keeping incompatible crossfades linear
- document the syntax and add coverage across parser, sequence, timeline, dump, and builder layers

## Verification
- go test ./...
- make build