### PR TITLE
perf(audio): optimize renderer efficiency

### DIFF
--- a/internal/audio/ambiance/audio.go
+++ b/internal/audio/ambiance/audio.go
@@ -18,3 +18,11 @@ func NewAudio(filePaths []string, expectedSampleRate int) (*Audio, error) {
 		SourceKind:   "ambiance",
 	})
 }
+
+func NewLazyAudio(filePaths []string, expectedSampleRate int) (*Audio, error) {
+	return audiosource.NewLazy(filePaths, expectedSampleRate, audiosource.Options{
+		PlaybackMode: audiosource.PlaybackLoop,
+		LoadFile:     r.GetAmbianceFile,
+		SourceKind:   "ambiance",
+	})
+}

--- a/internal/audio/audiosource/audio.go
+++ b/internal/audio/audiosource/audio.go
@@ -32,6 +32,7 @@ type Options struct {
 	PlaybackMode PlaybackMode
 	LoadFile     FileLoader
 	SourceKind   string
+	LazyLoad     bool
 }
 
 type Audio struct {
@@ -39,6 +40,8 @@ type Audio struct {
 	currentIndex int
 	playbackMode PlaybackMode
 	sourceKind   string
+	loadFile     FileLoader
+	expectedRate int
 
 	decoder       beep.StreamSeekCloser
 	sampleRate    int
@@ -49,13 +52,24 @@ type Audio struct {
 
 	cachedData [][]byte
 	formats    []t.AmbianceAudioFormat
+	validated  []bool
 	decoders   []beep.StreamSeekCloser
 
-	buffer     []int
-	bufferSize int
+	decodeBuffer [][2]float64
+	bufferSize   int
 }
 
 func New(filePaths []string, expectedSampleRate int, opts Options) (*Audio, error) {
+	return newAudio(filePaths, expectedSampleRate, opts)
+}
+
+// NewLazy defers file reads and format validation until a source is first played.
+func NewLazy(filePaths []string, expectedSampleRate int, opts Options) (*Audio, error) {
+	opts.LazyLoad = true
+	return newAudio(filePaths, expectedSampleRate, opts)
+}
+
+func newAudio(filePaths []string, expectedSampleRate int, opts Options) (*Audio, error) {
 	sourceKind := opts.SourceKind
 	if sourceKind == "" {
 		sourceKind = "external audio"
@@ -66,28 +80,38 @@ func New(filePaths []string, expectedSampleRate int, opts Options) (*Audio, erro
 	if opts.LoadFile == nil {
 		return nil, fmt.Errorf("%s file loader cannot be nil", sourceKind)
 	}
+	if expectedSampleRate <= 0 {
+		return nil, fmt.Errorf("invalid expected sample rate: %d", expectedSampleRate)
+	}
 
 	aa := &Audio{
 		filePaths:    filePaths,
 		currentIndex: 0,
 		playbackMode: opts.PlaybackMode,
 		sourceKind:   sourceKind,
+		loadFile:     opts.LoadFile,
+		expectedRate: expectedSampleRate,
+		sampleRate:   expectedSampleRate,
+		channels:     stereoChannels,
 		bufferSize:   t.BufferSize * stereoChannels,
 		cachedData:   make([][]byte, len(filePaths)),
 		formats:      make([]t.AmbianceAudioFormat, len(filePaths)),
+		validated:    make([]bool, len(filePaths)),
 		decoders:     make([]beep.StreamSeekCloser, len(filePaths)),
 	}
 
-	if err := aa.loadAndCacheAll(opts.LoadFile); err != nil {
-		return nil, err
+	if !opts.LazyLoad {
+		if err := aa.loadAndCacheAll(); err != nil {
+			return nil, err
+		}
+		if err := aa.validateTracks(); err != nil {
+			return nil, err
+		}
+		if err := aa.openFromCache(aa.currentIndex); err != nil {
+			return nil, fmt.Errorf("failed to open %s file: %w", aa.sourceKind, err)
+		}
 	}
-	if err := aa.validateTracks(expectedSampleRate); err != nil {
-		return nil, err
-	}
-	if err := aa.openFromCache(aa.currentIndex); err != nil {
-		return nil, fmt.Errorf("failed to open %s file: %w", aa.sourceKind, err)
-	}
-	aa.buffer = make([]int, aa.bufferSize)
+	aa.decodeBuffer = make([][2]float64, aa.bufferSize/stereoChannels)
 	return aa, nil
 }
 
@@ -111,80 +135,135 @@ func (aa *Audio) CachedData() [][]byte {
 	return aa.cachedData
 }
 
-func (aa *Audio) loadAndCacheAll(getFile FileLoader) error {
-	for i, path := range aa.filePaths {
-		if aa.cachedData[i] != nil {
-			continue
-		}
+// CloneAudio creates an independent playback cursor over the immutable cached assets.
+func (aa *Audio) CloneAudio() (SampleAudio, error) {
+	if aa == nil {
+		return nil, fmt.Errorf("audio is nil")
+	}
 
-		data, format, err := getFile(path)
-		if err != nil {
-			return fmt.Errorf("failed to load %s file [%d] (%s): %w", aa.sourceKind, i, path, err)
+	return &Audio{
+		filePaths:    aa.filePaths,
+		playbackMode: aa.playbackMode,
+		sourceKind:   aa.sourceKind,
+		loadFile:     aa.loadFile,
+		expectedRate: aa.expectedRate,
+		sampleRate:   aa.sampleRate,
+		channels:     aa.channels,
+		bitDepth:     aa.bitDepth,
+		cachedData:   aa.cachedData,
+		formats:      aa.formats,
+		validated:    aa.validated,
+		decoders:     make([]beep.StreamSeekCloser, len(aa.decoders)),
+		decodeBuffer: make([][2]float64, aa.bufferSize/stereoChannels),
+		bufferSize:   aa.bufferSize,
+	}, nil
+}
+
+// SelectAudio resets playback at index while retaining its decoder when possible.
+func (aa *Audio) SelectAudio(index int) error {
+	if aa == nil {
+		return fmt.Errorf("audio is nil")
+	}
+	if index < 0 || index >= len(aa.filePaths) {
+		return fmt.Errorf("invalid %s index: %d", aa.sourceKind, index)
+	}
+	if aa.decoders[index] == nil {
+		return aa.openFromCache(index)
+	}
+	if err := aa.decoders[index].Seek(0); err != nil {
+		return aa.restartAt(index)
+	}
+
+	aa.decoder = aa.decoders[index]
+	aa.currentIndex = index
+	aa.hasReachedEOF = false
+	return nil
+}
+
+func (aa *Audio) loadAndCacheAll() error {
+	for i, path := range aa.filePaths {
+		if err := aa.loadAndCache(i, path); err != nil {
+			return err
 		}
-		aa.cachedData[i] = data
-		aa.formats[i] = format
 	}
 	return nil
 }
 
-func (aa *Audio) validateTracks(expectedSampleRate int) error {
+func (aa *Audio) loadAndCache(index int, path string) error {
+	if aa.cachedData[index] != nil {
+		return nil
+	}
+
+	data, format, err := aa.loadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to load %s file [%d] (%s): %w", aa.sourceKind, index, path, err)
+	}
+	aa.cachedData[index] = data
+	aa.formats[index] = format
+	return nil
+}
+
+func (aa *Audio) validateTracks() error {
 	if len(aa.cachedData) == 0 {
 		return fmt.Errorf("no %s tracks loaded", aa.sourceKind)
 	}
-	if expectedSampleRate <= 0 {
-		return fmt.Errorf("invalid expected sample rate: %d", expectedSampleRate)
+
+	for i := range aa.cachedData {
+		if err := aa.validateTrack(i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (aa *Audio) validateTrack(i int) error {
+	data := aa.cachedData[i]
+	stream, format, err := decodeAudioData(data, aa.formats[i])
+	if err != nil {
+		return fmt.Errorf("failed to decode %s file [%d] (%s): %w", aa.sourceKind, i, aa.filePaths[i], err)
 	}
 
-	for i, data := range aa.cachedData {
-		stream, format, err := decodeAudioData(data, aa.formats[i])
+	sr := int(format.SampleRate)
+	ch := format.NumChannels
+
+	if err := stream.Close(); err != nil {
+		return fmt.Errorf("failed to close %s file [%d] (%s): %w", aa.sourceKind, i, aa.filePaths[i], err)
+	}
+
+	if ch != stereoChannels {
+		return fmt.Errorf("%s track [%d] (%s) has %d channel(s), expected %d", aa.sourceKind, i, aa.filePaths[i], ch, stereoChannels)
+	}
+
+	if sr != aa.expectedRate {
+		resampled, err := resampleAudioData(data, aa.formats[i], aa.expectedRate)
 		if err != nil {
-			return fmt.Errorf("failed to decode %s file [%d] (%s): %w", aa.sourceKind, i, aa.filePaths[i], err)
+			return fmt.Errorf("failed to resample %s file [%d] (%s) from %d Hz to %d Hz: %w", aa.sourceKind, i, aa.filePaths[i], sr, aa.expectedRate, err)
 		}
 
-		sr := int(format.SampleRate)
-		ch := format.NumChannels
+		aa.cachedData[i] = resampled
+		aa.formats[i] = t.AmbianceAudioWAV
+
+		stream, format, err = decodeAudioData(resampled, aa.formats[i])
+		if err != nil {
+			return fmt.Errorf("failed to decode resampled %s file [%d] (%s): %w", aa.sourceKind, i, aa.filePaths[i], err)
+		}
+
+		sr = int(format.SampleRate)
+		ch = format.NumChannels
 
 		if err := stream.Close(); err != nil {
-			return fmt.Errorf("failed to close %s file [%d] (%s): %w", aa.sourceKind, i, aa.filePaths[i], err)
+			return fmt.Errorf("failed to close resampled %s file [%d] (%s): %w", aa.sourceKind, i, aa.filePaths[i], err)
+		}
+
+		if sr != aa.expectedRate {
+			return fmt.Errorf("%s track [%d] (%s) has sample rate %d Hz after resample, expected %d Hz", aa.sourceKind, i, aa.filePaths[i], sr, aa.expectedRate)
 		}
 
 		if ch != stereoChannels {
-			return fmt.Errorf("%s track [%d] (%s) has %d channel(s), expected %d", aa.sourceKind, i, aa.filePaths[i], ch, stereoChannels)
-		}
-
-		if sr != expectedSampleRate {
-			resampled, err := resampleAudioData(data, aa.formats[i], expectedSampleRate)
-			if err != nil {
-				return fmt.Errorf("failed to resample %s file [%d] (%s) from %d Hz to %d Hz: %w", aa.sourceKind, i, aa.filePaths[i], sr, expectedSampleRate, err)
-			}
-
-			aa.cachedData[i] = resampled
-			aa.formats[i] = t.AmbianceAudioWAV
-
-			stream, format, err = decodeAudioData(resampled, aa.formats[i])
-			if err != nil {
-				return fmt.Errorf("failed to decode resampled %s file [%d] (%s): %w", aa.sourceKind, i, aa.filePaths[i], err)
-			}
-
-			sr = int(format.SampleRate)
-			ch = format.NumChannels
-
-			if err := stream.Close(); err != nil {
-				return fmt.Errorf("failed to close resampled %s file [%d] (%s): %w", aa.sourceKind, i, aa.filePaths[i], err)
-			}
-
-			if sr != expectedSampleRate {
-				return fmt.Errorf("%s track [%d] (%s) has sample rate %d Hz after resample, expected %d Hz", aa.sourceKind, i, aa.filePaths[i], sr, expectedSampleRate)
-			}
-
-			if ch != stereoChannels {
-				return fmt.Errorf("%s track [%d] (%s) has %d channel(s) after resample, expected %d", aa.sourceKind, i, aa.filePaths[i], ch, stereoChannels)
-			}
+			return fmt.Errorf("%s track [%d] (%s) has %d channel(s) after resample, expected %d", aa.sourceKind, i, aa.filePaths[i], ch, stereoChannels)
 		}
 	}
-
-	aa.sampleRate = expectedSampleRate
-	aa.channels = stereoChannels
+	aa.validated[i] = true
 	return nil
 }
 
@@ -244,11 +323,25 @@ type memoryWriteSeeker struct {
 }
 
 func (m *memoryWriteSeeker) Write(p []byte) (int, error) {
+	oldLen := len(m.data)
 	end := m.pos + len(p)
-	if end > len(m.data) {
-		grown := make([]byte, end)
+	if end > cap(m.data) {
+		capacity := cap(m.data)
+		if capacity == 0 {
+			capacity = 4096
+		}
+		for capacity < end {
+			capacity *= 2
+		}
+		grown := make([]byte, len(m.data), capacity)
 		copy(grown, m.data)
 		m.data = grown
+	}
+	if end > len(m.data) {
+		m.data = m.data[:end]
+	}
+	if m.pos > oldLen {
+		clear(m.data[oldLen:m.pos])
 	}
 	copy(m.data[m.pos:end], p)
 	m.pos = end
@@ -275,7 +368,7 @@ func (m *memoryWriteSeeker) Seek(offset int64, whence int) (int64, error) {
 }
 
 func (m *memoryWriteSeeker) Bytes() []byte {
-	return append([]byte(nil), m.data...)
+	return m.data
 }
 
 func (aa *Audio) openFromCache(index int) error {
@@ -283,7 +376,14 @@ func (aa *Audio) openFromCache(index int) error {
 		return fmt.Errorf("invalid %s index: %d", aa.sourceKind, index)
 	}
 	if aa.cachedData[index] == nil {
-		return fmt.Errorf("no cached data available for index: %d", index)
+		if err := aa.loadAndCache(index, aa.filePaths[index]); err != nil {
+			return err
+		}
+	}
+	if !aa.validated[index] {
+		if err := aa.validateTrack(index); err != nil {
+			return err
+		}
 	}
 
 	if aa.decoders[index] != nil {
@@ -382,7 +482,10 @@ func (aa *Audio) readFromDecoderAt(index int, samples []int, maxSamples int) (in
 		framesToRead = 1
 	}
 
-	buf := make([][2]float64, framesToRead)
+	if cap(aa.decodeBuffer) < framesToRead {
+		aa.decodeBuffer = make([][2]float64, framesToRead)
+	}
+	buf := aa.decodeBuffer[:framesToRead]
 	nFrames, ok := decoder.Stream(buf)
 	if !ok || nFrames == 0 {
 		if err := decoder.Err(); err != nil {

--- a/internal/audio/audiosource/audio_test.go
+++ b/internal/audio/audiosource/audio_test.go
@@ -6,10 +6,12 @@ package audiosource
 
 import (
 	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -197,6 +199,119 @@ func TestAudio_LoadReadAndLoop(t *testing.T) {
 	}
 }
 
+func TestAudioCloneSharesAssetsAndStartsIndependentPlayback(t *testing.T) {
+	path := filepath.Join("..", "testdata", "noise.wav")
+	aa, err := newLoopAudio([]string{path}, 44100)
+	if err != nil {
+		t.Fatalf("NewAudio: %v", err)
+	}
+	defer aa.Close()
+
+	cloned, err := aa.CloneAudio()
+	if err != nil {
+		t.Fatalf("CloneAudio: %v", err)
+	}
+	clone := cloned.(*Audio)
+	defer clone.Close()
+
+	if &aa.cachedData[0][0] != &clone.cachedData[0][0] {
+		t.Fatal("expected clone to share cached source data")
+	}
+
+	original := make([]int, stereoChannels)
+	copy := make([]int, stereoChannels)
+	if _, err := aa.ReadSamplesAt(0, original, len(original)); err != nil {
+		t.Fatalf("original ReadSamplesAt: %v", err)
+	}
+	if _, err := clone.ReadSamplesAt(0, copy, len(copy)); err != nil {
+		t.Fatalf("clone ReadSamplesAt: %v", err)
+	}
+	if !slices.Equal(original, copy) {
+		t.Fatalf("expected independent playback to start at same samples: original=%v clone=%v", original, copy)
+	}
+}
+
+func TestAudioSelectResetsExistingDecoder(t *testing.T) {
+	path := filepath.Join("..", "testdata", "noise.wav")
+	aa, err := newLoopAudio([]string{path}, 44100)
+	if err != nil {
+		t.Fatalf("NewAudio: %v", err)
+	}
+	defer aa.Close()
+
+	decoder := aa.decoders[0]
+	first := make([]int, stereoChannels)
+	if _, err := aa.ReadSamplesAt(0, first, len(first)); err != nil {
+		t.Fatalf("first ReadSamplesAt: %v", err)
+	}
+	if err := aa.SelectAudio(0); err != nil {
+		t.Fatalf("SelectAudio: %v", err)
+	}
+	if aa.decoders[0] != decoder {
+		t.Fatal("expected SelectAudio to retain the decoder")
+	}
+	reset := make([]int, stereoChannels)
+	if _, err := aa.ReadSamplesAt(0, reset, len(reset)); err != nil {
+		t.Fatalf("reset ReadSamplesAt: %v", err)
+	}
+	if !slices.Equal(first, reset) {
+		t.Fatalf("expected reset playback to match first samples: first=%v reset=%v", first, reset)
+	}
+}
+
+func BenchmarkAudioReadSamples(b *testing.B) {
+	path := filepath.Join("..", "testdata", "noise.wav")
+	aa, err := newLoopAudio([]string{path}, 44100)
+	if err != nil {
+		b.Fatalf("NewAudio: %v", err)
+	}
+	defer aa.Close()
+
+	samples := make([]int, t.BufferSize*stereoChannels)
+	b.SetBytes(int64(len(samples) * 2))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := aa.ReadSamplesAt(0, samples, len(samples)); err != nil {
+			b.Fatalf("ReadSamplesAt: %v", err)
+		}
+	}
+}
+
+func TestMemoryWriteSeekerGrowsGeometricallyAndRetainsContent(t *testing.T) {
+	writer := &memoryWriteSeeker{}
+	for range 10 {
+		if _, err := writer.Write(make([]byte, 1024)); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	if len(writer.data) != 10*1024 {
+		t.Fatalf("unexpected data length: %d", len(writer.data))
+	}
+	if cap(writer.data) < len(writer.data) || cap(writer.data) >= 2*len(writer.data) {
+		t.Fatalf("unexpected geometric capacity: %d", cap(writer.data))
+	}
+
+	if _, err := writer.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("Seek: %v", err)
+	}
+	if _, err := writer.Write([]byte{1, 2, 3}); err != nil {
+		t.Fatalf("Write after seek: %v", err)
+	}
+	if got := writer.Bytes()[:3]; !slices.Equal(got, []byte{1, 2, 3}) {
+		t.Fatalf("unexpected overwritten bytes: %v", got)
+	}
+	if _, err := writer.Seek(12*1024, io.SeekStart); err != nil {
+		t.Fatalf("Seek past end: %v", err)
+	}
+	if _, err := writer.Write([]byte{4}); err != nil {
+		t.Fatalf("Write past end: %v", err)
+	}
+	if got := writer.Bytes()[10*1024 : 12*1024]; !slices.Equal(got, make([]byte, len(got))) {
+		t.Fatalf("expected zero-filled seek gap, got %v", got[:3])
+	}
+}
+
 func TestAudio_LoadReadAndLoopMP3(t *testing.T) {
 	path := filepath.Join("..", "testdata", "noise.mp3")
 	data, sr, chans, depth := mustReadMP3All(t, path)
@@ -376,6 +491,41 @@ func TestAudio_MultipleIndicesHaveIndependentReadPosition(t *testing.T) {
 		if second0[i] != want {
 			t.Fatalf("index 0 continuation mismatch at %d: got %d want %d", i, second0[i], want)
 		}
+	}
+}
+
+func TestNewLazyLoadsAndValidatesOnlySelectedAudio(ts *testing.T) {
+	path := filepath.Join("..", "testdata", "noise.wav")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		ts.Fatalf("ReadFile: %v", err)
+	}
+
+	loads := make(map[string]int)
+	aa, err := NewLazy([]string{"first", "second"}, 44100, Options{
+		PlaybackMode: PlaybackLoop,
+		SourceKind:   "ambiance",
+		LoadFile: func(path string) ([]byte, t.AmbianceAudioFormat, error) {
+			loads[path]++
+			return data, t.AmbianceAudioWAV, nil
+		},
+	})
+	if err != nil {
+		ts.Fatalf("NewLazy: %v", err)
+	}
+	defer aa.Close()
+
+	if len(loads) != 0 {
+		ts.Fatalf("lazy constructor loaded files: %v", loads)
+	}
+	if err := aa.SelectAudio(1); err != nil {
+		ts.Fatalf("SelectAudio: %v", err)
+	}
+	if loads["second"] != 1 || len(loads) != 1 {
+		ts.Fatalf("expected only selected file to load, got %v", loads)
+	}
+	if aa.CachedData()[0] != nil || aa.CachedData()[1] == nil {
+		ts.Fatalf("unexpected lazy cache state: %v", aa.CachedData())
 	}
 }
 

--- a/internal/audio/audiosource/runtime.go
+++ b/internal/audio/audiosource/runtime.go
@@ -18,6 +18,14 @@ type SampleAudio interface {
 	Close() error
 }
 
+type cloneableSampleAudio interface {
+	CloneAudio() (SampleAudio, error)
+}
+
+type selectableSampleAudio interface {
+	SelectAudio(index int) error
+}
+
 type NewAudioFunc func(paths []string, sampleRate int) (SampleAudio, error)
 
 type BufferScope int
@@ -59,7 +67,8 @@ func NewRuntime(periods []t.Period, sources map[string]string, sampleRate int, o
 		sourceKind = "external audio"
 	}
 
-	paths, nameToIndex, err := BuildIndex(sources, sourceKind)
+	reachable := ReachableSources(periods, sources, opts.TrackType)
+	paths, nameToIndex, err := buildIndex(reachable, sourceKind, opts.Scope == BufferScopeChannel)
 	if err != nil {
 		return nil, err
 	}
@@ -114,6 +123,10 @@ func NewTestRuntime(sampleCount int) *Runtime {
 }
 
 func BuildIndex(sources map[string]string, sourceKind string) ([]string, map[string]int, error) {
+	return buildIndex(sources, sourceKind, false)
+}
+
+func buildIndex(sources map[string]string, sourceKind string, deduplicatePaths bool) ([]string, map[string]int, error) {
 	if len(sources) == 0 {
 		return nil, map[string]int{}, nil
 	}
@@ -124,19 +137,52 @@ func BuildIndex(sources map[string]string, sourceKind string) ([]string, map[str
 	}
 	sort.Strings(names)
 
-	paths := make([]string, len(names))
+	paths := make([]string, 0, len(names))
 	nameToIndex := make(map[string]int, len(names))
+	pathToIndex := make(map[string]int, len(names))
 
-	for i, name := range names {
+	for _, name := range names {
 		path := sources[name]
 		if path == "" {
 			return nil, nil, fmt.Errorf("%s %q has empty path", sourceKind, name)
 		}
-		paths[i] = path
-		nameToIndex[name] = i
+		if deduplicatePaths {
+			if index, ok := pathToIndex[path]; ok {
+				nameToIndex[name] = index
+				continue
+			}
+		}
+		nameToIndex[name] = len(paths)
+		pathToIndex[path] = len(paths)
+		paths = append(paths, path)
 	}
 
 	return paths, nameToIndex, nil
+}
+
+// ReachableSources returns declared sources referenced by periods or boundary crossfades.
+func ReachableSources(periods []t.Period, sources map[string]string, trackType t.TrackType) map[string]string {
+	reachable := make(map[string]string)
+	for _, period := range periods {
+		for channel := range t.NumberOfChannels {
+			tracks := []t.Track{
+				period.TrackStart[channel],
+				period.TrackEnd[channel],
+				period.CrossfadeOut[channel].Track,
+				period.CrossfadeIn[channel].Track,
+			}
+			for _, track := range tracks {
+				if track.Type != trackType {
+					continue
+				}
+				if path, ok := sources[track.SourceName]; ok {
+					reachable[track.SourceName] = path
+				}
+			}
+		}
+	}
+
+	return reachable
 }
 
 func PrecomputePeriodStart(periods []t.Period, nameToIndex map[string]int, trackType t.TrackType, sourceKind string) ([][]int, error) {
@@ -196,7 +242,16 @@ func (ar *Runtime) UpdateChannelIndex(ch int, periodIdx int, trackType t.TrackTy
 		nextIdx = ar.periodStart[periodIdx][ch]
 	}
 
-	if ar.scope == BufferScopeChannel && nextIdx != ar.channelIdx[ch] {
+	changedSource := nextIdx != ar.channelIdx[ch]
+	if ar.scope == BufferScopeChannel && changedSource {
+		if nextIdx >= 0 {
+			if audio, ok := ar.channelAudio[ch].(selectableSampleAudio); ok {
+				if err := audio.SelectAudio(nextIdx); err == nil {
+					ar.channelIdx[ch] = nextIdx
+					return
+				}
+			}
+		}
 		ar.closeChannelAudio(ch)
 	}
 	ar.channelIdx[ch] = nextIdx
@@ -247,6 +302,15 @@ func (ar *Runtime) CollectActiveIndices(channels []t.Channel) {
 		if !ar.activeMask[idx] {
 			ar.activeMask[idx] = true
 			ar.activeIdx = append(ar.activeIdx, idx)
+		}
+	}
+	ar.releaseInactiveSourceBuffers()
+}
+
+func (ar *Runtime) releaseInactiveSourceBuffers() {
+	for index := range ar.samplesByIdx {
+		if !ar.activeMask[index] {
+			ar.samplesByIdx[index] = nil
 		}
 	}
 }
@@ -312,6 +376,14 @@ func (ar *Runtime) audioForChannel(ch int) (SampleAudio, error) {
 	}
 	if ar.channelAudio[ch] != nil {
 		return ar.channelAudio[ch], nil
+	}
+	if template, ok := ar.audio.(cloneableSampleAudio); ok {
+		audio, err := template.CloneAudio()
+		if err != nil {
+			return nil, err
+		}
+		ar.channelAudio[ch] = audio
+		return audio, nil
 	}
 	if ar.newAudio == nil {
 		return nil, nil

--- a/internal/audio/audiosource/runtime_test.go
+++ b/internal/audio/audiosource/runtime_test.go
@@ -102,6 +102,106 @@ func TestMusicRuntimeKeepsEOFStatePerChannel(ts *testing.T) {
 	}
 }
 
+func TestReachableSourcesIncludesCrossfades(ts *testing.T) {
+	var period t.Period
+	period.TrackStart[0] = t.Track{Type: t.TrackMusic, SourceName: "start"}
+	period.TrackEnd[1] = t.Track{Type: t.TrackMusic, SourceName: "end"}
+	period.CrossfadeOut[2] = t.TrackCrossfade{Track: t.Track{Type: t.TrackMusic, SourceName: "out"}}
+	period.CrossfadeIn[3] = t.TrackCrossfade{Track: t.Track{Type: t.TrackMusic, SourceName: "in"}}
+
+	sources := map[string]string{
+		"start":  "start.mp3",
+		"end":    "end.mp3",
+		"out":    "out.mp3",
+		"in":     "in.mp3",
+		"unused": "unused.mp3",
+	}
+	reachable := ReachableSources([]t.Period{period}, sources, t.TrackMusic)
+	if len(reachable) != 4 {
+		ts.Fatalf("expected four reachable sources, got %v", reachable)
+	}
+	if _, ok := reachable["unused"]; ok {
+		ts.Fatalf("unexpected unused source: %v", reachable)
+	}
+}
+
+func TestRuntimeLoadsOnlyReachableSources(ts *testing.T) {
+	periods := []t.Period{{}}
+	periods[0].TrackStart[0] = t.Track{Type: t.TrackAmbiance, SourceName: "rain"}
+	var loadedPaths []string
+
+	runtime, err := NewRuntime(
+		periods,
+		map[string]string{"rain": "rain.wav", "unused": "unused.wav"},
+		44100,
+		RuntimeOptions{
+			TrackType:  t.TrackAmbiance,
+			SourceKind: "ambiance",
+			Scope:      BufferScopeSource,
+			NewAudio: func(paths []string, sampleRate int) (SampleAudio, error) {
+				loadedPaths = append([]string{}, paths...)
+				return newFiniteSampleAudio([][]int{{}}), nil
+			},
+		},
+	)
+	if err != nil {
+		ts.Fatalf("NewRuntime: %v", err)
+	}
+	defer runtime.Close()
+
+	if len(loadedPaths) != 1 || loadedPaths[0] != "rain.wav" {
+		ts.Fatalf("expected only rain.wav to load, got %v", loadedPaths)
+	}
+}
+
+func TestChannelRuntimeDeduplicatesIdenticalSourcePaths(ts *testing.T) {
+	periods := []t.Period{{}}
+	periods[0].TrackStart[0] = t.Track{Type: t.TrackMusic, SourceName: "intro"}
+	periods[0].TrackStart[1] = t.Track{Type: t.TrackMusic, SourceName: "repeat"}
+	var loadedPaths []string
+
+	runtime, err := NewRuntime(
+		periods,
+		map[string]string{"intro": "track.mp3", "repeat": "track.mp3"},
+		44100,
+		RuntimeOptions{
+			TrackType:  t.TrackMusic,
+			SourceKind: "music",
+			Scope:      BufferScopeChannel,
+			NewAudio: func(paths []string, sampleRate int) (SampleAudio, error) {
+				loadedPaths = append([]string(nil), paths...)
+				return newFiniteSampleAudio([][]int{{}}), nil
+			},
+		},
+	)
+	if err != nil {
+		ts.Fatalf("NewRuntime: %v", err)
+	}
+	defer runtime.Close()
+
+	if len(loadedPaths) != 1 || loadedPaths[0] != "track.mp3" {
+		ts.Fatalf("expected one shared source path, got %v", loadedPaths)
+	}
+	runtime.UpdateChannelIndex(0, 0, t.TrackMusic)
+	runtime.UpdateChannelIndex(1, 0, t.TrackMusic)
+	if runtime.channelIdx[0] != 0 || runtime.channelIdx[1] != 0 {
+		ts.Fatalf("expected aliases to share source index, got %v", runtime.channelIdx[:2])
+	}
+}
+
+func TestSourceRuntimeReleasesInactiveBuffers(ts *testing.T) {
+	runtime := NewTestRuntime(2)
+	runtime.samplesByIdx[0] = make([]int, 32)
+	runtime.samplesByIdx[1] = make([]int, 32)
+
+	channels := make([]t.Channel, t.NumberOfChannels)
+	runtime.CollectActiveIndices(channels)
+
+	if runtime.samplesByIdx[0] != nil || runtime.samplesByIdx[1] != nil {
+		ts.Fatalf("expected inactive source buffers to be released, got %v", runtime.samplesByIdx)
+	}
+}
+
 func equalSamples(a, b []int) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/audio/channelsignal.go
+++ b/internal/audio/channelsignal.go
@@ -22,8 +22,14 @@ type channelSignalState struct {
 }
 
 func (r *AudioRenderer) applyCueSignalState(cue audiosync.Cue) {
+	r.activeCount = 0
+	r.hasChannelPlan = true
 	for index := range cue.Channels {
 		channelCue := cue.Channels[index]
+		if channelCue.Track.Type != t.TrackOff && channelCue.Track.Type != t.TrackSilence {
+			r.activeChannels[r.activeCount] = index
+			r.activeCount++
+		}
 		r.signals[index] = channelSignalState{
 			resolved:    true,
 			kind:        channelCue.Track.Type,
@@ -34,8 +40,8 @@ func (r *AudioRenderer) applyCueSignalState(cue audiosync.Cue) {
 				End:   channelCue.WaveformEnd,
 				Alpha: channelCue.WaveformAlpha,
 			},
-			amplitude:   channelCue.Amplitude,
-			increment:   channelCue.Increment,
+			amplitude: channelCue.Amplitude,
+			increment: channelCue.Increment,
 		}
 	}
 }
@@ -56,7 +62,7 @@ func (r *AudioRenderer) signalStateFor(ch int, channel *t.Channel) channelSignal
 	}
 }
 
-func (state channelSignalState) sourceSignal() src.Signal {
+func (state *channelSignalState) sourceSignal() src.Signal {
 	return src.Signal{
 		Kind:        state.kind,
 		NoiseSmooth: state.noiseSmooth,

--- a/internal/audio/effects/processor.go
+++ b/internal/audio/effects/processor.go
@@ -10,10 +10,15 @@ const (
 )
 
 type Processor struct {
-	sampleRate int
-	waveTables [][]int
+	sampleRate         int
+	waveTables         [][]int
+	modulationMaxDelta float64
+	panMaxDelta        float64
 }
 
 func NewProcessor(sampleRate int, waveTables [][]int) *Processor {
-	return &Processor{sampleRate: sampleRate, waveTables: waveTables}
+	processor := &Processor{sampleRate: sampleRate, waveTables: waveTables}
+	processor.modulationMaxDelta = processor.effectSlewMaxDelta(modulationSlewTimeMs)
+	processor.panMaxDelta = 2 * processor.effectSlewMaxDelta(panSlewTimeMs)
+	return processor
 }

--- a/internal/audio/effects/smoothing.go
+++ b/internal/audio/effects/smoothing.go
@@ -13,7 +13,7 @@ func (p *Processor) smoothedModulationGain(channel *t.Channel, targetGain float6
 		return targetGain
 	}
 
-	maxDelta := p.effectSlewMaxDelta(modulationSlewTimeMs)
+	maxDelta := p.modulationMaxDelta
 	delta := targetGain - channel.Effect.ModulationGain
 	if delta > maxDelta {
 		delta = maxDelta
@@ -45,7 +45,7 @@ func (p *Processor) smoothedPanPosition(channel *t.Channel, targetX float64) flo
 		return targetX
 	}
 
-	maxDelta := 2 * p.effectSlewMaxDelta(panSlewTimeMs)
+	maxDelta := p.panMaxDelta
 	delta := targetX - channel.Effect.PanPosition
 	if delta > maxDelta {
 		delta = maxDelta

--- a/internal/audio/effects/waveform.go
+++ b/internal/audio/effects/waveform.go
@@ -19,7 +19,19 @@ func (p *Processor) WaveformValue(channel *t.Channel, offset int) float64 {
 }
 
 func (p *Processor) WaveformSampleForMorph(waveform WaveformMorph, offset int) int {
-	return int(math.Round(p.WaveformValueForMorph(waveform, offset)))
+	startWaveform, endWaveform, alpha := normalizedWaveformMorph(waveform)
+	idx := offset >> 16
+	start := p.waveTables[int(startWaveform)][idx]
+	if alpha <= 0 || startWaveform == endWaveform {
+		return start
+	}
+
+	end := p.waveTables[int(endWaveform)][idx]
+	if alpha >= 1 {
+		return end
+	}
+
+	return int(math.Round(float64(start) + float64(end-start)*alpha))
 }
 
 func (p *Processor) WaveformValueForMorph(waveform WaveformMorph, offset int) float64 {

--- a/internal/audio/mix.go
+++ b/internal/audio/mix.go
@@ -12,10 +12,18 @@ func (r *AudioRenderer) mix(samples []int) []int {
 	for i := range t.BufferSize {
 		var left, right int
 
-		for ch := range t.NumberOfChannels {
-			mixed := r.mixChannelSample(ch, i)
-			left += mixed.left
-			right += mixed.right
+		if r.hasChannelPlan {
+			for _, ch := range r.activeChannels[:r.activeCount] {
+				mixed := r.mixChannelSample(ch, i)
+				left += mixed.left
+				right += mixed.right
+			}
+		} else {
+			for ch := range t.NumberOfChannels {
+				mixed := r.mixChannelSample(ch, i)
+				left += mixed.left
+				right += mixed.right
+			}
 		}
 
 		final := r.finalizeMixedSample(left, right)

--- a/internal/audio/mix_benchmark_test.go
+++ b/internal/audio/mix_benchmark_test.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 SynapSeq Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package audio
+
+import (
+	"strconv"
+	"testing"
+
+	efx "github.com/synapseq-foundation/synapseq/v4/internal/audio/effects"
+	wt "github.com/synapseq-foundation/synapseq/v4/internal/audio/wavetable"
+	t "github.com/synapseq-foundation/synapseq/v4/internal/types"
+)
+
+var benchmarkSample int
+
+func BenchmarkMix(b *testing.B) {
+	for _, tracks := range []int{1, 4, 16} {
+		b.Run("tracks="+strconv.Itoa(tracks), func(b *testing.B) {
+			renderer := newBenchmarkMixRenderer(tracks)
+			samples := make([]int, t.BufferSize*audioChannels)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(samples) * 2))
+			b.ResetTimer()
+			for range b.N {
+				renderer.mix(samples)
+			}
+			benchmarkSample = samples[0]
+		})
+	}
+}
+
+func newBenchmarkMixRenderer(tracks int) *AudioRenderer {
+	renderer := newMixTestRenderer()
+	for channel := range tracks {
+		trackType := t.TrackPureTone
+		carrier := 180.0 + float64(channel*10)
+		resonance := 0.0
+		if channel%2 == 1 {
+			trackType = t.TrackBinauralBeat
+			resonance = 8
+		}
+
+		renderer.channels[channel] = t.Channel{
+			Track: t.Track{
+				Type:      trackType,
+				Carrier:   carrier,
+				Resonance: resonance,
+				Waveform:  t.WaveformSine,
+			},
+			WaveformStart: int(wt.SineID),
+			WaveformEnd:   int(wt.SineID),
+			Type:          trackType,
+			Amplitude:     [2]int{256, 256},
+			Increment: [2]int{
+				frequencyToIncrement(44100, carrier),
+				frequencyToIncrement(44100, carrier+resonance),
+			},
+		}
+		renderer.activeChannels[channel] = channel
+		renderer.signals[channel] = channelSignalState{
+			resolved:  true,
+			kind:      trackType,
+			waveform:  efx.WaveformMorph{Start: wt.SineID, End: wt.SineID},
+			amplitude: [2]int{256, 256},
+			increment: [2]int{
+				frequencyToIncrement(44100, carrier),
+				frequencyToIncrement(44100, carrier+resonance),
+			},
+		}
+	}
+	renderer.activeCount = tracks
+	renderer.hasChannelPlan = true
+
+	return renderer
+}

--- a/internal/audio/mix_test.go
+++ b/internal/audio/mix_test.go
@@ -10,6 +10,7 @@ import (
 
 	amb "github.com/synapseq-foundation/synapseq/v4/internal/audio/ambiance"
 	efx "github.com/synapseq-foundation/synapseq/v4/internal/audio/effects"
+	audiosync "github.com/synapseq-foundation/synapseq/v4/internal/audio/sync"
 	wt "github.com/synapseq-foundation/synapseq/v4/internal/audio/wavetable"
 	t "github.com/synapseq-foundation/synapseq/v4/internal/types"
 )
@@ -295,6 +296,46 @@ func TestAudioRendererMix_AmbianceUsesPreparedStereoBuffer(ts *testing.T) {
 
 	if samples[0] != expectedLeft || samples[1] != expectedRight {
 		ts.Fatalf("unexpected ambiance output: got [%d %d], want [%d %d]", samples[0], samples[1], expectedLeft, expectedRight)
+	}
+}
+
+func TestAudioRendererMix_UsesOnlyActiveCueChannels(ts *testing.T) {
+	renderer := newMixTestRenderer()
+	renderer.channels[0] = t.Channel{
+		Track:         t.Track{Type: t.TrackPureTone, Waveform: t.WaveformSquare},
+		WaveformStart: int(wt.SquareID),
+		WaveformEnd:   int(wt.SquareID),
+		Type:          t.TrackPureTone,
+		Amplitude:     [2]int{4096, 4096},
+		Increment:     [2]int{t.PhasePrecision, 0},
+	}
+	for channel := 1; channel < t.NumberOfChannels; channel++ {
+		renderer.channels[channel] = t.Channel{
+			Track:         t.Track{Type: t.TrackPureTone, Waveform: t.WaveformSquare},
+			WaveformStart: int(wt.SquareID),
+			WaveformEnd:   int(wt.SquareID),
+			Type:          t.TrackPureTone,
+			Amplitude:     [2]int{4096, 4096},
+			Increment:     [2]int{t.PhasePrecision, 0},
+		}
+	}
+
+	var cue audiosync.Cue
+	cue.Channels[0] = audiosync.ChannelCue{
+		Track:         renderer.channels[0].Track,
+		WaveformStart: wt.SquareID,
+		WaveformEnd:   wt.SquareID,
+		Amplitude:     [2]int{4096, 4096},
+		Increment:     [2]int{t.PhasePrecision, 0},
+	}
+	renderer.applyCueSignalState(cue)
+
+	samples := renderer.mix(make([]int, t.BufferSize*audioChannels))
+	if samples[0] != 32767 || samples[1] != 32767 {
+		ts.Fatalf("unexpected active-channel output: [%d %d]", samples[0], samples[1])
+	}
+	if renderer.channels[1].Offset != [2]int{} {
+		ts.Fatalf("inactive channel phase advanced: %v", renderer.channels[1].Offset)
 	}
 }
 

--- a/internal/audio/mixdispatch.go
+++ b/internal/audio/mixdispatch.go
@@ -13,7 +13,11 @@ type stereoSample struct {
 
 func (r *AudioRenderer) mixChannelSample(ch, frame int) stereoSample {
 	channel := &r.channels[ch]
-	signal := r.signalStateFor(ch, channel)
+	signal := &r.signals[ch]
+	if !signal.resolved {
+		fallback := r.signalStateFor(ch, channel)
+		signal = &fallback
+	}
 
 	switch signal.kind {
 	case t.TrackPureTone:
@@ -35,12 +39,12 @@ func (r *AudioRenderer) mixChannelSample(ch, frame int) stereoSample {
 	}
 }
 
-func (r *AudioRenderer) applyEffectToMono(channel *t.Channel, signal channelSignalState, sample int) stereoSample {
+func (r *AudioRenderer) applyEffectToMono(channel *t.Channel, signal *channelSignalState, sample int) stereoSample {
 	left, right := r.effectProcessor.ApplyEffectToMono(channel, signal.effect, signal.waveform, sample)
 	return applyAmplitude(signal.amplitude, left, right)
 }
 
-func (r *AudioRenderer) applyEffectToStereo(channel *t.Channel, signal channelSignalState, left, right int) stereoSample {
+func (r *AudioRenderer) applyEffectToStereo(channel *t.Channel, signal *channelSignalState, left, right int) stereoSample {
 	left, right = r.effectProcessor.ApplyEffectToStereo(channel, signal.effect, signal.waveform, left, right)
 	return applyAmplitude(signal.amplitude, left, right)
 }

--- a/internal/audio/mixsources.go
+++ b/internal/audio/mixsources.go
@@ -9,7 +9,7 @@ import (
 	t "github.com/synapseq-foundation/synapseq/v4/internal/types"
 )
 
-func (r *AudioRenderer) mixPureTone(channel *t.Channel, signal channelSignalState) stereoSample {
+func (r *AudioRenderer) mixPureTone(channel *t.Channel, signal *channelSignalState) stereoSample {
 	source := src.NewPureTone(signal.sourceSignal())
 	inc0 := r.effectProcessor.ApplyDoppler(channel, signal.effect, signal.increment[0])
 	channel.Offset[0] = advancePhase(channel.Offset[0], inc0)
@@ -18,7 +18,7 @@ func (r *AudioRenderer) mixPureTone(channel *t.Channel, signal channelSignalStat
 	return r.applyEffectToMono(channel, signal, sample)
 }
 
-func (r *AudioRenderer) mixBinauralBeat(channel *t.Channel, signal channelSignalState) stereoSample {
+func (r *AudioRenderer) mixBinauralBeat(channel *t.Channel, signal *channelSignalState) stereoSample {
 	source := src.NewBinaural(signal.sourceSignal())
 	inc0, inc1 := r.effectProcessor.ApplyDopplerPair(channel, signal.effect, signal.increment[0], signal.increment[1])
 	channel.Offset[0] = advancePhase(channel.Offset[0], inc0)
@@ -28,7 +28,7 @@ func (r *AudioRenderer) mixBinauralBeat(channel *t.Channel, signal channelSignal
 	return r.applyEffectToStereo(channel, signal, left, right)
 }
 
-func (r *AudioRenderer) mixMonauralBeat(channel *t.Channel, signal channelSignalState) stereoSample {
+func (r *AudioRenderer) mixMonauralBeat(channel *t.Channel, signal *channelSignalState) stereoSample {
 	source := src.NewMonaural(signal.sourceSignal())
 	inc0, inc1 := r.effectProcessor.ApplyDopplerPair(channel, signal.effect, signal.increment[0], signal.increment[1])
 	channel.Offset[0] = advancePhase(channel.Offset[0], inc0)
@@ -39,7 +39,7 @@ func (r *AudioRenderer) mixMonauralBeat(channel *t.Channel, signal channelSignal
 	return r.applyEffectToMono(channel, signal, mixed)
 }
 
-func (r *AudioRenderer) mixIsochronicBeat(channel *t.Channel, signal channelSignalState) stereoSample {
+func (r *AudioRenderer) mixIsochronicBeat(channel *t.Channel, signal *channelSignalState) stereoSample {
 	source := src.NewIsochronic(signal.sourceSignal())
 	incCarrier := r.effectProcessor.ApplyDoppler(channel, signal.effect, signal.increment[0])
 	channel.Offset[0] = advancePhase(channel.Offset[0], incCarrier)
@@ -51,13 +51,13 @@ func (r *AudioRenderer) mixIsochronicBeat(channel *t.Channel, signal channelSign
 	return r.applyEffectToMono(channel, signal, out)
 }
 
-func (r *AudioRenderer) mixNoise(channel *t.Channel, signal channelSignalState) stereoSample {
+func (r *AudioRenderer) mixNoise(channel *t.Channel, signal *channelSignalState) stereoSample {
 	source := src.NewNoise(signal.sourceSignal())
 	sample := source.Sample(r.noiseGenerator)
 	return r.applyEffectToMono(channel, signal, sample)
 }
 
-func (r *AudioRenderer) mixAmbiance(channel *t.Channel, signal channelSignalState, ch, frame int) stereoSample {
+func (r *AudioRenderer) mixAmbiance(channel *t.Channel, signal *channelSignalState, ch, frame int) stereoSample {
 	source := src.NewAmbiance(signal.sourceSignal())
 	left, right, ok := source.Sample(r.ambianceState, ch, frame)
 	if !ok {
@@ -67,7 +67,7 @@ func (r *AudioRenderer) mixAmbiance(channel *t.Channel, signal channelSignalStat
 	return r.applyEffectToStereo(channel, signal, left, right)
 }
 
-func (r *AudioRenderer) mixMusic(channel *t.Channel, signal channelSignalState, ch, frame int) stereoSample {
+func (r *AudioRenderer) mixMusic(channel *t.Channel, signal *channelSignalState, ch, frame int) stereoSample {
 	source := src.NewAmbiance(signal.sourceSignal())
 	left, right, ok := source.Sample(r.musicState, ch, frame)
 	if !ok {

--- a/internal/audio/music/audio.go
+++ b/internal/audio/music/audio.go
@@ -18,3 +18,11 @@ func NewAudio(filePaths []string, expectedSampleRate int) (*Audio, error) {
 		SourceKind:   "music",
 	})
 }
+
+func NewLazyAudio(filePaths []string, expectedSampleRate int) (*Audio, error) {
+	return audiosource.NewLazy(filePaths, expectedSampleRate, audiosource.Options{
+		PlaybackMode: audiosource.PlaybackFinite,
+		LoadFile:     r.GetMusicFile,
+		SourceKind:   "music",
+	})
+}

--- a/internal/audio/noise.go
+++ b/internal/audio/noise.go
@@ -26,12 +26,18 @@ const (
 	noiseSmoothnessMinAlpha             = 0.02
 )
 
+const (
+	noiseSmoothWhiteIndex = iota
+	noiseSmoothPinkIndex
+	noiseSmoothBrownIndex
+)
+
 // NoiseGenerator handles all noise generation
 type NoiseGenerator struct {
 	pinkState   pinkNoiseState
 	seed        uint32
 	brownLast   int
-	smoothState map[t.TrackType]noiseSmoothnessState
+	smoothState [3]noiseSmoothnessState
 }
 
 // pinkNoiseState holds the per-band state for the Voss-McCartney pink noise generator.
@@ -60,10 +66,7 @@ type noiseSmoothnessProfile struct {
 
 // NewNoiseGenerator creates a new noise generator with initial seed
 func NewNoiseGenerator() *NoiseGenerator {
-	ng := &NoiseGenerator{
-		seed:        initialNoiseSeed,
-		smoothState: make(map[t.TrackType]noiseSmoothnessState),
-	}
+	ng := &NoiseGenerator{seed: initialNoiseSeed}
 	ng.initPinkNoise()
 	return ng
 }
@@ -171,14 +174,17 @@ func (ng *NoiseGenerator) applySmoothness(tr t.TrackType, smooth float64, sample
 		smooth = 100
 	}
 
-	state := ng.smoothState[tr]
+	stateIndex, ok := noiseSmoothnessStateIndex(tr)
+	if !ok {
+		return sample
+	}
+	state := &ng.smoothState[stateIndex]
 
 	if !state.initialized {
 		for idx := range state.stages {
 			state.stages[idx] = float64(sample)
 		}
 		state.initialized = true
-		ng.smoothState[tr] = state
 		return sample
 	}
 
@@ -189,8 +195,20 @@ func (ng *NoiseGenerator) applySmoothness(tr t.TrackType, smooth float64, sample
 		value = state.stages[idx]
 	}
 
-	ng.smoothState[tr] = state
 	return clampNoiseSample(int(value))
+}
+
+func noiseSmoothnessStateIndex(tr t.TrackType) (int, bool) {
+	switch tr {
+	case t.TrackWhiteNoise:
+		return noiseSmoothWhiteIndex, true
+	case t.TrackPinkNoise:
+		return noiseSmoothPinkIndex, true
+	case t.TrackBrownNoise:
+		return noiseSmoothBrownIndex, true
+	default:
+		return 0, false
+	}
 }
 
 // noiseSmoothnessAlpha returns the noise smoothing alpha for a given track and smoothness level.

--- a/internal/audio/noise_test.go
+++ b/internal/audio/noise_test.go
@@ -217,7 +217,7 @@ func TestNoise_SmoothnessRampPreservesFilterState(ts *testing.T) {
 		prevReset = ngReset.Generate(t.TrackPinkNoise, 100)
 	}
 
-	ngReset.smoothState[t.TrackPinkNoise] = noiseSmoothnessState{}
+	ngReset.smoothState[noiseSmoothPinkIndex] = noiseSmoothnessState{}
 
 	outPreserved := ngPreserved.Generate(t.TrackPinkNoise, 50)
 	outReset := ngReset.Generate(t.TrackPinkNoise, 50)
@@ -225,8 +225,8 @@ func TestNoise_SmoothnessRampPreservesFilterState(ts *testing.T) {
 	deltaPreserved := absInt(outPreserved - prevPreserved)
 	deltaReset := absInt(outReset - prevReset)
 
-	if len(ngPreserved.smoothState) != 1 {
-		ts.Fatalf("expected a single smooth state entry for ramped pink noise, got %d", len(ngPreserved.smoothState))
+	if !ngPreserved.smoothState[noiseSmoothPinkIndex].initialized {
+		ts.Fatalf("expected pink noise smoothing state to remain initialized")
 	}
 	if deltaPreserved >= deltaReset {
 		ts.Fatalf("expected preserved filter state to reduce transition discontinuity, got preserved=%d reset=%d", deltaPreserved, deltaReset)

--- a/internal/audio/output/streamer.go
+++ b/internal/audio/output/streamer.go
@@ -9,22 +9,31 @@ import p "github.com/synapseq-foundation/synapseq/v4/internal/audio/pcm"
 type RenderFunc func(consume func(samples []int) error) error
 
 type RendererStreamer struct {
-	ch       chan []int
-	leftover []int
-	done     bool
-	err      error
+	ch      chan []int
+	free    chan []int
+	current []int
+	offset  int
+	done    bool
+	err     error
 }
 
 func NewRendererStreamer(render RenderFunc) *RendererStreamer {
 	rs := &RendererStreamer{
-		ch: make(chan []int, 2),
+		ch:   make(chan []int, 2),
+		free: make(chan []int, 3),
+	}
+	for range cap(rs.free) {
+		rs.free <- nil
 	}
 	go func() {
 		defer close(rs.ch)
 		rs.err = render(func(samples []int) error {
-			cpy := make([]int, len(samples))
-			copy(cpy, samples)
-			rs.ch <- cpy
+			buffer := <-rs.free
+			if cap(buffer) < len(samples) {
+				buffer = make([]int, 0, len(samples))
+			}
+			buffer = append(buffer[:0], samples...)
+			rs.ch <- buffer
 			return nil
 		})
 	}()
@@ -32,22 +41,23 @@ func NewRendererStreamer(render RenderFunc) *RendererStreamer {
 }
 
 func (rs *RendererStreamer) Stream(samples [][2]float64) (n int, ok bool) {
-	if rs.done && len(rs.leftover) == 0 {
+	if rs.done && rs.current == nil {
 		return 0, false
 	}
 
 	for n < len(samples) {
-		if len(rs.leftover) < 2 {
+		if rs.current == nil {
 			data, more := <-rs.ch
 			if !more {
 				rs.done = true
 				break
 			}
-			rs.leftover = data
+			rs.current = data
+			rs.offset = 0
 		}
-		framesAvail := len(rs.leftover) / 2
+		framesAvail := (len(rs.current) - rs.offset) / 2
 		if framesAvail == 0 {
-			rs.leftover = nil
+			rs.releaseCurrent()
 			continue
 		}
 		need := len(samples) - n
@@ -55,16 +65,28 @@ func (rs *RendererStreamer) Stream(samples [][2]float64) (n int, ok bool) {
 			need = framesAvail
 		}
 		for i := 0; i < need; i++ {
-			l := rs.leftover[2*i]
-			r := rs.leftover[2*i+1]
+			l := rs.current[rs.offset+2*i]
+			r := rs.current[rs.offset+2*i+1]
 			samples[n+i][0] = p.SampleToUnitFloat64(l)
 			samples[n+i][1] = p.SampleToUnitFloat64(r)
 		}
-		rs.leftover = rs.leftover[need*2:]
+		rs.offset += need * 2
+		if rs.offset == len(rs.current) {
+			rs.releaseCurrent()
+		}
 		n += need
 	}
-	ok = !rs.done || len(rs.leftover) > 0 || n > 0
+	ok = !rs.done || rs.current != nil || n > 0
 	return
+}
+
+func (rs *RendererStreamer) releaseCurrent() {
+	select {
+	case rs.free <- rs.current[:0]:
+	default:
+	}
+	rs.current = nil
+	rs.offset = 0
 }
 
 func (rs *RendererStreamer) Err() error {

--- a/internal/audio/output/wavoutput_test.go
+++ b/internal/audio/output/wavoutput_test.go
@@ -65,6 +65,37 @@ func TestWAVOutput_Write_EmitsDecodableWAV(ts *testing.T) {
 	}
 }
 
+func BenchmarkRendererStreamer(b *testing.B) {
+	const chunks = 64
+	samples := make([]int, 2048)
+	for i := range samples {
+		samples[i] = i
+	}
+	output := make([][2]float64, 512)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		streamer := NewRendererStreamer(func(consume func([]int) error) error {
+			for range chunks {
+				if err := consume(samples); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		for {
+			_, ok := streamer.Stream(output)
+			if !ok {
+				break
+			}
+		}
+		if err := streamer.Err(); err != nil {
+			b.Fatalf("stream error: %v", err)
+		}
+	}
+}
+
 type byteReadSeekCloser struct {
 	*bytes.Reader
 }

--- a/internal/audio/renderer.go
+++ b/internal/audio/renderer.go
@@ -28,6 +28,9 @@ const (
 type AudioRenderer struct {
 	channels        [t.NumberOfChannels]t.Channel
 	signals         [t.NumberOfChannels]channelSignalState
+	activeChannels  [t.NumberOfChannels]int
+	activeCount     int
+	hasChannelPlan  bool
 	plan            renderPlan
 	periods         []t.Period
 	waveTables      [][]int
@@ -80,13 +83,13 @@ func NewAudioRenderer(p []t.Period, ar *AudioRendererOptions) (*AudioRenderer, e
 	}
 
 	ambianceState, err := amb.NewRuntime(p, ar.Ambiance, ar.SampleRate, func(paths []string, sampleRate int) (amb.SampleAudio, error) {
-		return amb.NewAudio(paths, sampleRate)
+		return amb.NewLazyAudio(paths, sampleRate)
 	})
 	if err != nil {
 		return nil, err
 	}
 	musicState, err := mus.NewRuntime(p, ar.Music, ar.SampleRate, func(paths []string, sampleRate int) (mus.SampleAudio, error) {
-		return mus.NewAudio(paths, sampleRate)
+		return mus.NewLazyAudio(paths, sampleRate)
 	})
 	if err != nil {
 		if ambianceState != nil {

--- a/internal/audio/renderplan.go
+++ b/internal/audio/renderplan.go
@@ -23,6 +23,7 @@ type renderPlan struct {
 	sampleRate  int
 	totalFrames int64
 	waveforms   []periodWaveforms
+	active      [][t.NumberOfChannels]bool
 	transitions map[string][]float64
 }
 
@@ -59,6 +60,7 @@ func compileRenderPlanWithWaveformsAndTransitions(periods []t.Period, sampleRate
 		sampleRate:  sampleRate,
 		totalFrames: totalFramesFromDuration(durationMs(periods), sampleRate),
 		waveforms:   make([]periodWaveforms, len(periods)),
+		active:      make([][t.NumberOfChannels]bool, len(periods)),
 		transitions: transitions,
 	}
 
@@ -74,6 +76,7 @@ func compileRenderPlanWithWaveformsAndTransitions(periods []t.Period, sampleRate
 			EndMs:       endMs,
 		}
 		for channel := range t.NumberOfChannels {
+			plan.active[index][channel] = periodCanProduceAudio(periods[index], channel)
 			plan.waveforms[index].Start[channel], _ = registry.Lookup(periods[index].TrackStart[channel].Waveform)
 			plan.waveforms[index].End[channel], _ = registry.Lookup(periods[index].TrackEnd[channel].Waveform)
 			plan.waveforms[index].CrossfadeOut[channel], _ = registry.Lookup(periods[index].CrossfadeOut[channel].Track.Waveform)
@@ -102,6 +105,9 @@ func (rp renderPlan) cue(periodIdx int, currentTimeMs int) audiosync.Cue {
 	}
 
 	for index := 0; index < t.NumberOfChannels; index++ {
+		if !rp.active[periodIdx][index] {
+			continue
+		}
 		track, waveformStart, waveformEnd, waveformAlpha, crossfade := rp.trackStateAt(window, period, index, alpha, currentTimeMs)
 		signal := compileSignalState(planTrackState{
 			track:      track,
@@ -120,6 +126,21 @@ func (rp renderPlan) cue(periodIdx int, currentTimeMs int) audiosync.Cue {
 	}
 
 	return cue
+}
+
+func periodCanProduceAudio(period t.Period, channel int) bool {
+	tracks := [...]t.Track{
+		period.TrackStart[channel],
+		period.TrackEnd[channel],
+		period.CrossfadeOut[channel].Track,
+		period.CrossfadeIn[channel].Track,
+	}
+	for _, track := range tracks {
+		if track.Type != t.TrackOff && track.Type != t.TrackSilence {
+			return true
+		}
+	}
+	return false
 }
 
 func (rp renderPlan) trackStateAt(window renderWindow, period t.Period, ch int, alpha float64, currentTimeMs int) (t.Track, wt.ID, wt.ID, float64, audiosync.CrossfadeCue) {


### PR DESCRIPTION
## Summary
- avoid inactive-channel work and reuse renderer and WAV streaming buffers
- lazy-load reachable external assets and share music source data safely
- reduce mixer hot-path copies and optimize noise, smoothing, and wavetable paths

## Validation
- ok  	github.com/synapseq-foundation/synapseq/v4/cmd/synapseq	0.910s
ok  	github.com/synapseq-foundation/synapseq/v4/core	1.502s
ok  	github.com/synapseq-foundation/synapseq/v4/external	0.591s
ok  	github.com/synapseq-foundation/synapseq/v4/internal/ai	(cached)
ok  	github.com/synapseq-foundation/synapseq/v4/internal/audio	2.061s
ok  	github.com/synapseq-foundation/synapseq/v4/internal/audio/ambiance	1.866s
ok  	github.com/synapseq-foundation/synapseq/v4/internal/audio/audiosource	1.338s
ok  	github.com/synapseq-foundation/synapseq/v4/internal/audio/effects	0.331s
ok  	github.com/synapseq-foundation/synapseq/v4/internal/audio/music	2.342s
ok  	github.com/synapseq-foundation/synapseq/v4/internal/audio/output	2.477s
?   	github.com/synapseq-foundation/synapseq/v4/internal/audio/pcm	[no test files]
ok  	github.com/synapseq-foundation/synapseq/v4/internal/audio/sources	2.838s
ok  	github.com/synapseq-foundation/synapseq/v4/internal/audio/status	(cached)
ok  	github.com/synapseq-foundation/synapseq/v4/internal/audio/sync	(cached)
ok  	github.com/synapseq-foundation/synapseq/v4/internal/audio/wavetable	(cached)
ok  	github.com/synapseq-foundation/synapseq/v4/internal/cli	(cached)
ok  	github.com/synapseq-foundation/synapseq/v4/internal/diag	(cached)
ok  	github.com/synapseq-foundation/synapseq/v4/internal/dump	(cached)
?   	github.com/synapseq-foundation/synapseq/v4/internal/info	[no test files]
ok  	github.com/synapseq-foundation/synapseq/v4/internal/nameref	(cached)
ok  	github.com/synapseq-foundation/synapseq/v4/internal/palette	(cached)
ok  	github.com/synapseq-foundation/synapseq/v4/internal/parser	(cached)
ok  	github.com/synapseq-foundation/synapseq/v4/internal/preset	(cached)
ok  	github.com/synapseq-foundation/synapseq/v4/internal/remote	(cached)
ok  	github.com/synapseq-foundation/synapseq/v4/internal/resource	(cached)
ok  	github.com/synapseq-foundation/synapseq/v4/internal/sequence	(cached)
?   	github.com/synapseq-foundation/synapseq/v4/internal/textstyle	[no test files]
ok  	github.com/synapseq-foundation/synapseq/v4/internal/timeline	(cached)
ok  	github.com/synapseq-foundation/synapseq/v4/internal/types	(cached)
ok  	github.com/synapseq-foundation/synapseq/v4/sbg	2.892s
ok  	github.com/synapseq-foundation/synapseq/v4/spsq	2.903s
- mkdir -p bin
go build -ldflags="-s -w -X github.com/synapseq-foundation/synapseq/v4/internal/info.VERSION=4.42.0-foundation -X github.com/synapseq-foundation/synapseq/v4/internal/info.BUILD_DATE=2026-08-25T01:02:43Z -X github.com/synapseq-foundation/synapseq/v4/internal/info.GIT_COMMIT=dd98369" -o bin/synapseq ./cmd/synapseq
- manual SPSQ validation

## Benchmarks
- 16 active tracks: approximately 291 us to 126 us per chunk
- WAV renderer streamer: approximately 253 KiB to 50 KiB per 64-chunk render